### PR TITLE
Fix duplicate OAuth-failure notifications (thread race)

### DIFF
--- a/reddit_scraper/sources.py
+++ b/reddit_scraper/sources.py
@@ -49,6 +49,27 @@ def record_fetch_success():
     _LAST_FETCH_SUCCESS_TS = time.time()
 
 
+def _claim_auth_error_notification():
+    """Atomically claim the right to send the one-time OAuth-failure notification.
+
+    Monitors run concurrently, so without this guard every thread that hits the same
+    401 fires its own notification. Returns True for exactly one caller until reset
+    on the next oauth success.
+    """
+    global _auth_error_notified
+    with _source_state_lock:
+        if _auth_error_notified:
+            return False
+        _auth_error_notified = True
+        return True
+
+
+def _reset_auth_error_notification():
+    global _auth_error_notified
+    with _source_state_lock:
+        _auth_error_notified = False
+
+
 def _source_available(name):
     with _source_state_lock:
         return time.time() >= _source_cooldown_until.get(name, 0)
@@ -237,7 +258,6 @@ def fetch_posts(subreddit, limit, reddit):
 
     Returns (posts, source_name), or (None, None) if every source failed.
     """
-    global _auth_error_notified
     for source in config.get_source_order():
         if not _source_available(source):
             continue
@@ -255,10 +275,9 @@ def fetch_posts(subreddit, limit, reddit):
         except Exception as e:
             error_str = str(e)
             if source == 'oauth' and ('401' in error_str or 'unauthorized' in error_str.lower()):
-                if not _auth_error_notified:
+                if _claim_auth_error_notification():
                     notifications.notify_error(
                         "Reddit API authentication failed (401). Falling back to alternative sources (RSS/JSON).")
-                    _auth_error_notified = True
             logging.warning(f"Reddit source '{source}' failed for r/{subreddit}: {e}")
             _mark_source_down(source)
             continue
@@ -269,7 +288,7 @@ def fetch_posts(subreddit, limit, reddit):
             continue
 
         if source == 'oauth':
-            _auth_error_notified = False
+            _reset_auth_error_notification()
         record_fetch_success()
         _set_active_source(source)
         return posts, source

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -141,3 +141,27 @@ class TestFetchPostsDispatcher:
         assert source == 'oauth'
         assert sources._active_source == 'oauth'
         assert sources._LAST_FETCH_SUCCESS_TS is not None
+
+
+class TestAuthErrorNotificationGuard:
+
+    def test_concurrent_401s_notify_only_once(self, monkeypatch):
+        """6 monitors hitting the same OAuth 401 in parallel must produce one alert."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        def oauth_401(reddit, sub, lim):
+            raise RuntimeError("received 401 HTTP response")
+        monkeypatch.setattr(sources, '_fetch_posts_oauth', oauth_401)
+        monkeypatch.setattr(sources, 'fetch_posts_rss', lambda sub, lim: self._post())
+
+        calls = []
+        monkeypatch.setattr(sources.notifications, 'notify_error', lambda msg: calls.append(msg))
+
+        with ThreadPoolExecutor(max_workers=6) as ex:
+            list(ex.map(lambda i: sources.fetch_posts('gamedeals', 10, reddit=object()), range(6)))
+
+        assert len(calls) == 1
+
+    def _post(self):
+        return [{'id': '1', 'title': 't', 'url': '', 'score': 0,
+                 'permalink': '/p', 'domain': '', 'link_flair_text': '', 'author': 'a'}]


### PR DESCRIPTION
## Problem
Observed in production: a single OAuth 401 produced **6 Pushover alerts at once**. The `_auth_error_notified` "notify once" flag was checked and set non-atomically, and monitors run concurrently via `ThreadPoolExecutor`, so all threads saw `False` before any set `True`.

## Fix
Atomic check-and-set under the existing `_source_state_lock` (`_claim_auth_error_notification` / `_reset_auth_error_notification`). Exactly one notification per outage; reset on the next oauth success.

## Test
`test_concurrent_401s_notify_only_once` spawns 6 threads on the same 401 and asserts one `notify_error` call. Suite: 72 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)