### PR TITLE
Coalesce duplicate fetches + exponential backoff + prefer JSON over RSS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,9 +21,11 @@ KUMA_FETCH_STALE_SECONDS=1500
 KUMA_FALLBACK_PUSH_URL=
 
 # --- Data source pathways ---
-# Order to try when fetching posts/comments. Comma-separated subset of: oauth,rss,json
-# (search.json "source_order" overrides this). Default: oauth,rss,json
-REDDIT_SOURCE_ORDER=oauth,rss,json
+# Order to try when fetching posts/comments. Comma-separated subset of: oauth,json,rss
+# (search.json "source_order" overrides this). Default: oauth,json,rss
+# JSON is ordered before RSS because, when it works, it returns full post data
+# (score/domain/flair) that RSS can't; backoff keeps the dead source from being retried hot.
+REDDIT_SOURCE_ORDER=oauth,json,rss
 # Minimum seconds between RSS requests (RSS is per-IP rate-limited). Default 4.
 RSS_MIN_INTERVAL_SECONDS=4
 # How long to skip a source after it errors/gets blocked, in seconds. Default 300.

--- a/readme.md
+++ b/readme.md
@@ -274,32 +274,34 @@ The bot fetches posts/comments through an ordered chain of sources, trying each 
 
 | Source | Auth | Notes |
 |--------|------|-------|
-| `oauth` | Reddit app | Authenticated API (full login **or** read-only app-only). Unblocked, 100 req/min, the only source that provides **score** and **domain**. |
-| `rss` | None | `www.reddit.com/r/<sub>/new/.rss`. Works without credentials but is per-IP rate-limited, so requests are throttled. No score/domain (see filter note above). |
-| `json` | None | `old.reddit.com/.../new.json`. Mostly blocked by Reddit now; kept as a last resort. |
+| `oauth` | Reddit app | Authenticated API (full login **or** read-only app-only). Unblocked, 100 req/min, full post data. |
+| `json` | None | `old.reddit.com/.../new.json`. Often blocked by Reddit now, but when it works it returns **full post data (score, domain, flair)** — so it's preferred over RSS. |
+| `rss` | None | `www.reddit.com/r/<sub>/new/.rss`. Works without credentials but is per-IP rate-limited (throttled) and has **no score/domain** (see filter note above). |
 
-The active source is shown in the web UI; when OAuth is configured but the bot has fallen back, a banner indicates the degradation.
+Duplicate/concurrent requests for the same subreddit (or thread) are **coalesced** into a single fetch, and a failed source is cooled down with **exponential backoff** so a blocked endpoint isn't retried hot. The active source is shown in the web UI; when OAuth is configured but the bot has fallen back, a banner indicates the degradation.
 
 ### Configuring the order
 
-Default is `oauth → rss → json`. Override per deployment via `search.json`:
+Default is `oauth → json → rss` (JSON before RSS because it returns richer data when available). Override per deployment via `search.json`:
 
 ```json
 {
-    "source_order": ["oauth", "rss", "json"],
+    "source_order": ["oauth", "json", "rss"],
     "subreddits_to_search": [ ... ]
 }
 ```
 
-…or with the `REDDIT_SOURCE_ORDER=oauth,rss,json` environment variable (`search.json` takes precedence).
+…or with the `REDDIT_SOURCE_ORDER=oauth,json,rss` environment variable (`search.json` takes precedence).
 
 ### Environment variables
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `REDDIT_SOURCE_ORDER` | `oauth,rss,json` | Source chain order (overridden by `search.json`) |
+| `REDDIT_SOURCE_ORDER` | `oauth,json,rss` | Source chain order (overridden by `search.json`) |
 | `RSS_MIN_INTERVAL_SECONDS` | `4` | Minimum gap between RSS requests (rate-limit safety) |
-| `SOURCE_COOLDOWN_SECONDS` | `300` | How long to skip a source after it errors/gets blocked |
+| `SOURCE_COOLDOWN_SECONDS` | `300` | Base cooldown after a source errors/gets blocked |
+| `SOURCE_COOLDOWN_MAX_SECONDS` | `3600` | Cap on the exponential backoff cooldown |
+| `FETCH_CACHE_TTL_SECONDS` | `90` | How long a fetched result is shared across duplicate monitors |
 | `RSS_USER_AGENT` | (browser UA) | Override the User-Agent used for RSS requests |
 | `KUMA_PUSH_URL` | — | Uptime Kuma Push URL for the primary health heartbeat |
 | `KUMA_FETCH_STALE_SECONDS` | `1500` | Seconds without a successful fetch before reporting DOWN |

--- a/reddit_scraper/config.py
+++ b/reddit_scraper/config.py
@@ -17,11 +17,14 @@ OPTIONAL_LIST_FIELDS = ['exclude_keywords', 'domain_contains', 'domain_excludes'
                         'flair_contains', 'author_includes', 'author_excludes']
 
 # Data-source pathways, tried in order by the dispatcher:
-#   'oauth' - authenticated PRAW API (full login OR app-only read-only).
-#   'rss'   - www.reddit.com Atom feed (no creds, rate-limited).
-#   'json'  - anonymous old.reddit.com JSON (mostly blocked; last resort).
+#   'oauth' - authenticated PRAW API (full login OR app-only read-only). Richest + unblocked.
+#   'json'  - anonymous old.reddit.com JSON. Often blocked, but when it works it returns
+#             full post data (score, domain, flair) unlike RSS, so it's preferred over RSS.
+#   'rss'   - www.reddit.com Atom feed (no creds, rate-limited, no score/domain). Last resort.
+# Backoff (see sources._mark_source_down) keeps a blocked source from being retried hot,
+# so ordering a richer-but-flakier source first costs only an occasional cheap re-probe.
 VALID_SOURCES = ('oauth', 'rss', 'json')
-DEFAULT_SOURCE_ORDER = ['oauth', 'rss', 'json']
+DEFAULT_SOURCE_ORDER = ['oauth', 'json', 'rss']
 
 
 # --- Paths (call-time, env-aware) ---

--- a/reddit_scraper/sources.py
+++ b/reddit_scraper/sources.py
@@ -34,13 +34,23 @@ _active_source = None
 _auth_error_notified = False
 
 _source_cooldown_until = {}      # source name -> epoch time until which it is skipped
+_source_failures = {}            # source name -> consecutive failure count (for backoff)
 _source_state_lock = threading.Lock()
-SOURCE_COOLDOWN_SECONDS = int(os.getenv('SOURCE_COOLDOWN_SECONDS', '300'))  # skip a blocked source for 5 min
+SOURCE_COOLDOWN_SECONDS = int(os.getenv('SOURCE_COOLDOWN_SECONDS', '300'))      # base cooldown
+SOURCE_COOLDOWN_MAX = int(os.getenv('SOURCE_COOLDOWN_MAX_SECONDS', '3600'))     # cap on backoff
 
 # RSS is aggressively per-IP rate-limited, so serialize requests with a minimum gap.
 _rss_throttle_lock = threading.Lock()
 _rss_last_request = [0.0]
 RSS_MIN_INTERVAL = float(os.getenv('RSS_MIN_INTERVAL_SECONDS', '4'))
+
+# Short-lived response cache so concurrent monitors covering the same subreddit/thread
+# share a single network request instead of each issuing its own (which both wastes
+# requests and trips rate limits). TTL only needs to span one scheduling burst.
+FETCH_CACHE_TTL = float(os.getenv('FETCH_CACHE_TTL_SECONDS', '90'))
+_fetch_cache = {}                # key -> (timestamp, value)
+_fetch_cache_lock = threading.Lock()
+_fetch_key_locks = {}            # key -> Lock (so concurrent callers coalesce, not stampede)
 
 
 def record_fetch_success():
@@ -76,10 +86,47 @@ def _source_available(name):
 
 
 def _mark_source_down(name, seconds=None):
-    cooldown = seconds or SOURCE_COOLDOWN_SECONDS
+    """Cool down a failed source. With no explicit duration, back off exponentially on
+    consecutive failures (base, 2x, 4x, ... capped) so a flagged IP / dead source gets
+    a real rest instead of being retried every cycle."""
     with _source_state_lock:
+        if seconds is None:
+            n = _source_failures.get(name, 0) + 1
+            _source_failures[name] = n
+            cooldown = min(SOURCE_COOLDOWN_SECONDS * (2 ** (n - 1)), SOURCE_COOLDOWN_MAX)
+        else:
+            cooldown = seconds
         _source_cooldown_until[name] = time.time() + cooldown
-    logging.warning(f"Pausing Reddit source '{name}' for {cooldown}s after failure")
+    logging.warning(f"Pausing Reddit source '{name}' for {int(cooldown)}s after failure")
+
+
+def _note_source_success(name):
+    """Reset a source's backoff after it succeeds."""
+    with _source_state_lock:
+        _source_failures[name] = 0
+
+
+def _coalesce(key, producer):
+    """Return a cached fresh value for key, or produce + cache it. Concurrent callers
+    for the same key wait on a per-key lock and share the single result."""
+    now = time.time()
+    with _fetch_cache_lock:
+        entry = _fetch_cache.get(key)
+        if entry and now - entry[0] < FETCH_CACHE_TTL:
+            return entry[1]
+        key_lock = _fetch_key_locks.setdefault(key, threading.Lock())
+
+    with key_lock:
+        # Re-check inside the per-key lock: another thread may have just produced it.
+        now = time.time()
+        with _fetch_cache_lock:
+            entry = _fetch_cache.get(key)
+            if entry and now - entry[0] < FETCH_CACHE_TTL:
+                return entry[1]
+        value = producer()
+        with _fetch_cache_lock:
+            _fetch_cache[key] = (time.time(), value)
+        return value
 
 
 def _set_active_source(source):
@@ -254,6 +301,13 @@ def _fetch_posts_oauth(reddit, subreddit, limit):
 
 
 def fetch_posts(subreddit, limit, reddit):
+    """Fetch posts, coalescing concurrent/duplicate calls for the same subreddit+limit
+    so overlapping monitors share one request. See _fetch_posts_impl for the chain."""
+    return _coalesce(('posts', subreddit, limit),
+                     lambda: _fetch_posts_impl(subreddit, limit, reddit))
+
+
+def _fetch_posts_impl(subreddit, limit, reddit):
     """Try each configured source in order until one returns data.
 
     Returns (posts, source_name), or (None, None) if every source failed.
@@ -289,6 +343,7 @@ def fetch_posts(subreddit, limit, reddit):
 
         if source == 'oauth':
             _reset_auth_error_notification()
+        _note_source_success(source)
         record_fetch_success()
         _set_active_source(source)
         return posts, source
@@ -298,6 +353,13 @@ def fetch_posts(subreddit, limit, reddit):
 
 
 def fetch_thread_comments(subreddit, thread_id, reddit):
+    """Fetch a thread's comments, coalescing concurrent/duplicate calls for the same
+    thread so overlapping monitors share one request. See _fetch_thread_comments_impl."""
+    return _coalesce(('comments', subreddit, thread_id),
+                     lambda: _fetch_thread_comments_impl(subreddit, thread_id, reddit))
+
+
+def _fetch_thread_comments_impl(subreddit, thread_id, reddit):
     """Fetch a thread's comments through the configured source chain (oauth -> rss -> json)."""
     for source in config.get_source_order():
         if not _source_available(source):
@@ -333,6 +395,7 @@ def fetch_thread_comments(subreddit, thread_id, reddit):
             _mark_source_down(source)
             continue
 
+        _note_source_success(source)
         record_fetch_success()
         return comments
 

--- a/search.json.example
+++ b/search.json.example
@@ -1,5 +1,5 @@
 {
-    "source_order": ["oauth", "rss", "json"],
+    "source_order": ["oauth", "json", "rss"],
     "subreddits_to_search": [
         {
             "id": "example-1",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,7 +15,7 @@ class TestSourceOrder:
 
     def test_default_when_unset(self):
         config.set_source_order(None)
-        assert config.get_source_order() == ['oauth', 'rss', 'json']
+        assert config.get_source_order() == ['oauth', 'json', 'rss']
 
     def test_drops_invalid_names_and_keeps_order(self):
         config.set_source_order(['json', 'bogus', 'rss', 'oauth'])
@@ -23,7 +23,7 @@ class TestSourceOrder:
 
     def test_empty_after_cleaning_falls_back_to_default(self):
         config.set_source_order(['nonsense', ''])
-        assert config.get_source_order() == ['oauth', 'rss', 'json']
+        assert config.get_source_order() == ['oauth', 'json', 'rss']
 
     def test_returns_a_copy(self):
         config.set_source_order(['rss'])
@@ -47,4 +47,4 @@ class TestApplySourceOrderFromConfig:
     def test_falls_back_to_default_when_neither_set(self, monkeypatch):
         monkeypatch.delenv('REDDIT_SOURCE_ORDER', raising=False)
         config.apply_source_order_from_config({})
-        assert config.get_source_order() == ['oauth', 'rss', 'json']
+        assert config.get_source_order() == ['oauth', 'json', 'rss']

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -7,14 +7,18 @@ from reddit_scraper import sources, config
 
 @pytest.fixture(autouse=True)
 def reset_source_state():
-    """Source state is module-global; reset it (and disable RSS throttling) per test."""
+    """Source state is module-global; reset it (and disable RSS throttling/caching) per test."""
     sources._source_cooldown_until.clear()
+    sources._source_failures.clear()
+    sources._fetch_cache.clear()
+    sources._fetch_key_locks.clear()
     sources._active_source = None
     sources._LAST_FETCH_SUCCESS_TS = None
     sources._auth_error_notified = False
     sources._rss_last_request[0] = 0.0
     sources.RSS_MIN_INTERVAL = 0
-    config.set_source_order(None)  # back to default oauth -> rss -> json
+    sources.FETCH_CACHE_TTL = 0  # disable caching by default; coalescing tests opt back in
+    config.set_source_order(None)  # back to default oauth -> json -> rss
     yield
 
 
@@ -93,50 +97,58 @@ class TestFetchThreadCommentsRss:
         assert c['body'] == 'WTS shirt size Small $20'      # HTML tags stripped
 
 
+def _post():
+    return [{'id': '1', 'title': 't', 'url': '', 'score': 0,
+             'permalink': '/p', 'domain': '', 'link_flair_text': '', 'author': 'a'}]
+
+
+def _raises(*a, **k):
+    raise RuntimeError("blocked")
+
+
 class TestFetchPostsDispatcher:
+    """Tests set source order explicitly so they don't depend on the production default."""
 
-    def _post(self):
-        return [{'id': '1', 'title': 't', 'url': '', 'score': 0,
-                 'permalink': '/p', 'domain': '', 'link_flair_text': '', 'author': 'a'}]
+    def test_skips_oauth_when_no_reddit_and_uses_next_source(self, monkeypatch):
+        config.set_source_order(['oauth', 'json', 'rss'])
+        monkeypatch.setattr(sources, 'fetch_posts_json', lambda sub, lim: _post())
+        monkeypatch.setattr(sources, 'fetch_posts_rss', lambda sub, lim: _post())
+        posts, source = sources.fetch_posts('gamedeals', 10, reddit=None)
+        assert source == 'json'          # oauth skipped (no reddit), json is next
+        assert sources._active_source == 'json'
 
-    def test_skips_oauth_when_no_reddit_and_uses_rss(self, monkeypatch):
-        monkeypatch.setattr(sources, 'fetch_posts_rss', lambda sub, lim: self._post())
+    def test_falls_through_on_failure_and_cools_down(self, monkeypatch):
+        config.set_source_order(['json', 'rss'])
+        monkeypatch.setattr(sources, 'fetch_posts_json', _raises)
+        monkeypatch.setattr(sources, 'fetch_posts_rss', lambda sub, lim: [])
         posts, source = sources.fetch_posts('gamedeals', 10, reddit=None)
         assert source == 'rss'
-        assert len(posts) == 1
-        assert sources._active_source == 'rss'
-
-    def test_falls_through_to_json_and_cools_down_failed_source(self, monkeypatch):
-        def boom(*a, **k):
-            raise RuntimeError("RSS blocked (429)")
-        monkeypatch.setattr(sources, 'fetch_posts_rss', boom)
-        monkeypatch.setattr(sources, 'fetch_posts_json', lambda sub, lim: [])
-        posts, source = sources.fetch_posts('gamedeals', 10, reddit=None)
-        assert source == 'json'
         assert posts == []
-        assert not sources._source_available('rss')        # rss is on cooldown
+        assert not sources._source_available('json')       # failed source on cooldown
 
     def test_returns_none_when_all_sources_fail(self, monkeypatch):
-        monkeypatch.setattr(sources, 'fetch_posts_rss', lambda sub, lim: (_ for _ in ()).throw(RuntimeError()))
-        monkeypatch.setattr(sources, 'fetch_posts_json', lambda sub, lim: None)
+        config.set_source_order(['json', 'rss'])
+        monkeypatch.setattr(sources, 'fetch_posts_json', _raises)
+        monkeypatch.setattr(sources, 'fetch_posts_rss', lambda sub, lim: None)
         posts, source = sources.fetch_posts('gamedeals', 10, reddit=None)
         assert posts is None and source is None
 
     def test_cooldown_source_is_skipped(self, monkeypatch):
-        sources._mark_source_down('rss', 300)
-        called = {'rss': False}
+        config.set_source_order(['json', 'rss'])
+        sources._mark_source_down('json', 300)
+        called = {'json': False}
 
-        def rss(sub, lim):
-            called['rss'] = True
-            return self._post()
-        monkeypatch.setattr(sources, 'fetch_posts_rss', rss)
-        monkeypatch.setattr(sources, 'fetch_posts_json', lambda sub, lim: self._post())
+        def json_fetch(sub, lim):
+            called['json'] = True
+            return _post()
+        monkeypatch.setattr(sources, 'fetch_posts_json', json_fetch)
+        monkeypatch.setattr(sources, 'fetch_posts_rss', lambda sub, lim: _post())
         posts, source = sources.fetch_posts('gamedeals', 10, reddit=None)
-        assert source == 'json'          # rss skipped due to cooldown
-        assert called['rss'] is False
+        assert source == 'rss'           # json skipped due to cooldown
+        assert called['json'] is False
 
     def test_oauth_success_sets_active_source_and_records_success(self, monkeypatch):
-        monkeypatch.setattr(sources, '_fetch_posts_oauth', lambda r, sub, lim: self._post())
+        monkeypatch.setattr(sources, '_fetch_posts_oauth', lambda r, sub, lim: _post())
         posts, source = sources.fetch_posts('gamedeals', 10, reddit=object())
         assert source == 'oauth'
         assert sources._active_source == 'oauth'
@@ -149,10 +161,11 @@ class TestAuthErrorNotificationGuard:
         """6 monitors hitting the same OAuth 401 in parallel must produce one alert."""
         from concurrent.futures import ThreadPoolExecutor
 
-        def oauth_401(reddit, sub, lim):
-            raise RuntimeError("received 401 HTTP response")
-        monkeypatch.setattr(sources, '_fetch_posts_oauth', oauth_401)
-        monkeypatch.setattr(sources, 'fetch_posts_rss', lambda sub, lim: self._post())
+        monkeypatch.setattr(sources, '_fetch_posts_oauth',
+                            lambda reddit, sub, lim: (_ for _ in ()).throw(RuntimeError("received 401 HTTP response")))
+        # next source serves so the chain completes (stub both to avoid the network)
+        monkeypatch.setattr(sources, 'fetch_posts_json', lambda sub, lim: _post())
+        monkeypatch.setattr(sources, 'fetch_posts_rss', lambda sub, lim: _post())
 
         calls = []
         monkeypatch.setattr(sources.notifications, 'notify_error', lambda msg: calls.append(msg))
@@ -162,6 +175,88 @@ class TestAuthErrorNotificationGuard:
 
         assert len(calls) == 1
 
-    def _post(self):
-        return [{'id': '1', 'title': 't', 'url': '', 'score': 0,
-                 'permalink': '/p', 'domain': '', 'link_flair_text': '', 'author': 'a'}]
+
+class TestCoalescing:
+
+    def test_duplicate_subreddit_shares_one_request(self, monkeypatch):
+        sources.FETCH_CACHE_TTL = 90
+        calls = {'n': 0}
+
+        def served(sub, lim):
+            calls['n'] += 1
+            return _post()
+        monkeypatch.setattr(sources, 'fetch_posts_json', served)
+
+        r1 = sources.fetch_posts('frugalmalefashion', 10, None)
+        r2 = sources.fetch_posts('frugalmalefashion', 10, None)
+        assert calls['n'] == 1          # second served from cache
+        assert r1 == r2
+
+    def test_concurrent_duplicates_coalesce_to_one(self, monkeypatch):
+        from concurrent.futures import ThreadPoolExecutor
+        import time
+        sources.FETCH_CACHE_TTL = 90
+        calls = {'n': 0}
+
+        def served(sub, lim):
+            calls['n'] += 1
+            time.sleep(0.05)            # widen the race window
+            return _post()
+        monkeypatch.setattr(sources, 'fetch_posts_json', served)
+
+        with ThreadPoolExecutor(max_workers=5) as ex:
+            list(ex.map(lambda i: sources.fetch_posts('frugalmalefashion', 10, None), range(5)))
+        assert calls['n'] == 1
+
+    def test_different_subreddits_not_shared(self, monkeypatch):
+        sources.FETCH_CACHE_TTL = 90
+        calls = {'n': 0}
+        monkeypatch.setattr(sources, 'fetch_posts_json',
+                            lambda sub, lim: (calls.__setitem__('n', calls['n'] + 1) or _post()))
+        sources.fetch_posts('gamedeals', 10, None)
+        sources.fetch_posts('apphookup', 10, None)
+        assert calls['n'] == 2
+
+    def test_whole_chain_is_coalesced(self, monkeypatch):
+        """Coalescing wraps the entire chain, so every source (incl. JSON) fires once per burst."""
+        sources.FETCH_CACHE_TTL = 90
+        config.set_source_order(['json', 'rss'])
+        json_calls = {'n': 0}
+        rss_calls = {'n': 0}
+        monkeypatch.setattr(sources, 'fetch_posts_json',
+                            lambda sub, lim: (json_calls.__setitem__('n', json_calls['n'] + 1) or _raises()))
+        monkeypatch.setattr(sources, 'fetch_posts_rss',
+                            lambda sub, lim: (rss_calls.__setitem__('n', rss_calls['n'] + 1) or _post()))
+        sources.fetch_posts('gamedeals', 10, None)
+        sources.fetch_posts('gamedeals', 10, None)
+        assert json_calls['n'] == 1 and rss_calls['n'] == 1   # whole chain ran once, then cached
+
+
+class TestBackoff:
+
+    def test_exponential_backoff_on_consecutive_failures(self):
+        import time
+        sources._mark_source_down('rss')                       # 1st: base (300s)
+        first = sources._source_cooldown_until['rss'] - time.time()
+        sources._mark_source_down('rss')                       # 2nd: 2x (600s)
+        second = sources._source_cooldown_until['rss'] - time.time()
+        assert 290 < first <= sources.SOURCE_COOLDOWN_SECONDS
+        assert second > first * 1.5                            # roughly doubled
+
+    def test_success_resets_backoff(self):
+        sources._mark_source_down('rss')
+        sources._mark_source_down('rss')
+        assert sources._source_failures['rss'] == 2
+        sources._note_source_success('rss')
+        assert sources._source_failures['rss'] == 0
+
+    def test_backoff_capped(self, monkeypatch):
+        monkeypatch.setattr(sources, 'SOURCE_COOLDOWN_MAX', 1000)
+        import time
+        for _ in range(10):
+            sources._mark_source_down('rss')
+        assert sources._source_cooldown_until['rss'] - time.time() <= 1000
+
+    def test_explicit_seconds_does_not_increment_failures(self):
+        sources._mark_source_down('rss', 50)
+        assert sources._source_failures.get('rss', 0) == 0


### PR DESCRIPTION
## Context
With OAuth temporarily unavailable, the bot leans on the no-auth fallbacks — but the NAS IP is rate-limited, and production logs showed **6 monitors across only 3 unique subreddits** each issuing their own requests and tripping 429s.

## Changes
1. **Coalesce duplicate fetches** — concurrent/duplicate calls for the same `(subreddit, limit)` (or `(subreddit, thread_id)`) share one request via a short-TTL cache + per-key lock. Roughly halves request volume given the overlap. Because it wraps the whole `oauth→json→rss` chain, the **JSON fallback is coalesced too**.
2. **Exponential backoff** — consecutive source failures back off `base → 2× → 4× …` capped at `SOURCE_COOLDOWN_MAX_SECONDS`, so a blocked source/flagged IP gets a real rest (and is re-probed occasionally) instead of retried every cycle. Reset on success.
3. **Default order `oauth → json → rss`** — JSON returns full post data (score/domain/flair) that RSS can't, so it's preferred; backoff keeps ordering a richer-but-flakier source first cheap.

## New env vars
- `SOURCE_COOLDOWN_MAX_SECONDS` (default 3600) — backoff cap
- `FETCH_CACHE_TTL_SECONDS` (default 90) — coalescing window

## Tests
80 passed. Added coverage for coalescing (sequential + concurrent + whole-chain incl. JSON), exponential backoff (growth, cap, reset, explicit-bypass), and reworked dispatcher tests to set explicit source order (no longer coupled to the default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)