### PR TITLE
Add Sylvia gateway source + proxy/IP-hiding for anonymous fetches

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,10 +21,13 @@ KUMA_FETCH_STALE_SECONDS=1500
 KUMA_FALLBACK_PUSH_URL=
 
 # --- Data source pathways ---
-# Order to try when fetching posts/comments. Comma-separated subset of: oauth,json,rss
+# Order to try when fetching posts/comments. Comma-separated subset of: oauth,json,rss,sylvia
 # (search.json "source_order" overrides this). Default: oauth,json,rss
 # JSON is ordered before RSS because, when it works, it returns full post data
 # (score/domain/flair) that RSS can't; backoff keeps the dead source from being retried hot.
+# 'sylvia' is a paid third-party gateway (see below) and is only tried when SYLVIA_API_KEY
+# is set; a good setup is oauth,sylvia,json,rss (Sylvia as the main fallback, json/rss as a
+# free last-ditch net behind it).
 REDDIT_SOURCE_ORDER=oauth,json,rss
 # Minimum seconds between RSS requests (RSS is per-IP rate-limited). Default 4.
 RSS_MIN_INTERVAL_SECONDS=4
@@ -32,3 +35,28 @@ RSS_MIN_INTERVAL_SECONDS=4
 SOURCE_COOLDOWN_SECONDS=300
 # Optional: override the browser User-Agent used for RSS requests.
 RSS_USER_AGENT=
+
+# --- Sylvia gateway (optional, paid third-party) ---
+# api.sylvia-api.com is a Reddit gateway returning full native-JSON post/comment data from
+# its own IP. Add 'sylvia' to REDDIT_SOURCE_ORDER above to use it. It's authenticated and
+# billed per successful request; the free tier allows 480 req/min (far above this bot's
+# volume). Leave the key blank to disable the source entirely (no requests, no charges).
+SYLVIA_API_KEY=
+# Optional overrides (defaults shown):
+# SYLVIA_BASE_URL=https://api.sylvia-api.com/v1/reddit
+# SYLVIA_TIMEOUT_SECONDS=15
+
+# --- Proxying / IP hiding (optional) ---
+# Route the anonymous RSS/JSON requests through a proxy so they aren't all made from
+# your one IP (the IP Reddit ends up rate-limiting / flagging). OAuth (PRAW) is left
+# direct. Leave both unset for direct requests (default; no behavior change).
+#   REDDIT_PROXY   - a single proxy URL, e.g. http://user:pass@host:8000
+#                    or socks5://127.0.0.1:9050 (socks needs `pip install requests[socks]`)
+#   REDDIT_PROXIES - a comma-separated pool, rotated per request; a proxy that fails
+#                    to connect is skipped for PROXY_COOLDOWN_SECONDS, then retried.
+# When either is set, requests NEVER fall back to a direct connection, so a configured
+# proxy can't silently leak your real IP if it goes down.
+REDDIT_PROXY=
+REDDIT_PROXIES=
+# How long to skip a proxy after it fails to connect, in seconds. Default 120.
+PROXY_COOLDOWN_SECONDS=120

--- a/api.py
+++ b/api.py
@@ -340,6 +340,7 @@ def get_credentials_status():
         'has_notifications': len(notification_urls) > 0,
         'notification_count': len(notification_urls),
         'has_reddit_username': bool(creds.get('reddit_username')),
+        'has_sylvia': bool(creds.get('sylvia_api_key')),
     })
 
 
@@ -365,6 +366,7 @@ def get_credentials():
         'reddit_username': creds.get('reddit_username', ''),
         'reddit_password': mask_value(creds.get('reddit_password', '')),
         'reddit_user_agent': creds.get('reddit_user_agent', ''),
+        'sylvia_api_key': mask_value(creds.get('sylvia_api_key', '')),
         'notification_urls': notification_urls,  # Return full URLs for editing
         'notification_urls_masked': masked_urls,  # Masked for display
     })
@@ -441,8 +443,8 @@ def update_credentials():
         creds = load_credentials()
         
         # Only update fields that are provided and not masked
-        fields = ['reddit_client_id', 'reddit_client_secret', 'reddit_username', 
-                  'reddit_password', 'reddit_user_agent']
+        fields = ['reddit_client_id', 'reddit_client_secret', 'reddit_username',
+                  'reddit_password', 'reddit_user_agent', 'sylvia_api_key']
         
         for field in fields:
             if field in data:

--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -14,6 +14,7 @@ interface Credentials {
     reddit_username: string;
     reddit_password: string;
     reddit_user_agent: string;
+    sylvia_api_key: string;
     notification_urls: string[];
 }
 
@@ -23,6 +24,7 @@ const DEFAULT_CREDENTIALS: Credentials = {
     reddit_username: '',
     reddit_password: '',
     reddit_user_agent: '',
+    sylvia_api_key: '',
     notification_urls: [],
 };
 
@@ -227,6 +229,27 @@ export default function SettingsModal({ onClose, onSave }: SettingsModalProps) {
                                                 className="input-field text-sm"
                                             />
                                         </div>
+                                    </div>
+                                </div>
+
+                                {/* Sylvia Gateway Section */}
+                                <div>
+                                    <h3 className="text-sm font-semibold text-white/80 mb-3 flex items-center gap-2">
+                                        🛰️ Sylvia Gateway <span className="text-xs text-white/40 font-normal">(optional fallback)</span>
+                                    </h3>
+                                    <div>
+                                        <label className="text-xs text-white/60 block mb-1">API Key</label>
+                                        <input
+                                            type="password"
+                                            value={credentials.sylvia_api_key}
+                                            onChange={(e) => handleChange('sylvia_api_key', e.target.value)}
+                                            placeholder="syl_..."
+                                            className="input-field text-sm"
+                                        />
+                                        <p className="text-xs text-white/40 mt-1">
+                                            Third-party Reddit gateway used as a fallback when the API is unavailable.
+                                            Add <code className="text-white/60">sylvia</code> to your source order to enable it.
+                                        </p>
                                     </div>
                                 </div>
 

--- a/reddit_scraper/config.py
+++ b/reddit_scraper/config.py
@@ -17,13 +17,16 @@ OPTIONAL_LIST_FIELDS = ['exclude_keywords', 'domain_contains', 'domain_excludes'
                         'flair_contains', 'author_includes', 'author_excludes']
 
 # Data-source pathways, tried in order by the dispatcher:
-#   'oauth' - authenticated PRAW API (full login OR app-only read-only). Richest + unblocked.
-#   'json'  - anonymous old.reddit.com JSON. Often blocked, but when it works it returns
-#             full post data (score, domain, flair) unlike RSS, so it's preferred over RSS.
-#   'rss'   - www.reddit.com Atom feed (no creds, rate-limited, no score/domain). Last resort.
+#   'oauth'  - authenticated PRAW API (full login OR app-only read-only). Richest + unblocked.
+#   'json'   - anonymous old.reddit.com JSON. Often blocked, but when it works it returns
+#              full post data (score, domain, flair) unlike RSS, so it's preferred over RSS.
+#   'rss'    - www.reddit.com Atom feed (no creds, rate-limited, no score/domain). Last resort.
+#   'sylvia' - api.sylvia-api.com third-party Reddit gateway (full native-JSON data, hides
+#              our IP, but PAID per request and needs SYLVIA_API_KEY). Opt-in: not in the
+#              default order, and skipped entirely unless a key is set (see sources).
 # Backoff (see sources._mark_source_down) keeps a blocked source from being retried hot,
 # so ordering a richer-but-flakier source first costs only an occasional cheap re-probe.
-VALID_SOURCES = ('oauth', 'rss', 'json')
+VALID_SOURCES = ('oauth', 'rss', 'json', 'sylvia')
 DEFAULT_SOURCE_ORDER = ['oauth', 'json', 'rss']
 
 

--- a/reddit_scraper/credentials.py
+++ b/reddit_scraper/credentials.py
@@ -61,6 +61,7 @@ def load_credentials():
         'reddit_user_agent': creds.get('reddit_user_agent') or os.getenv('REDDIT_USER_AGENT'),
         'reddit_username': creds.get('reddit_username') or os.getenv('REDDIT_USERNAME'),
         'reddit_password': creds.get('reddit_password') or os.getenv('REDDIT_PASSWORD'),
+        'sylvia_api_key': creds.get('sylvia_api_key') or os.getenv('SYLVIA_API_KEY'),
     }
 
 
@@ -115,6 +116,14 @@ def detect_auth_capability():
     global CREDENTIALS
     CREDENTIALS = load_credentials()
     check_credential_encoding(CREDENTIALS)
+
+    # Bridge the optional Sylvia gateway key into the sources layer (lazy import to avoid
+    # the sources -> notifications -> credentials import cycle). Env var still works on its
+    # own; this lets the key be set via the UI/credentials file too.
+    from . import sources
+    sources.SYLVIA_API_KEY = CREDENTIALS.get('sylvia_api_key')
+    if CREDENTIALS.get('sylvia_api_key'):
+        logging.info("🛰️  Sylvia gateway key configured (source 'sylvia' available if in the order).")
 
     has_app = bool(CREDENTIALS.get('reddit_client_id') and CREDENTIALS.get('reddit_client_secret'))
     has_login = has_app and bool(CREDENTIALS.get('reddit_username') and CREDENTIALS.get('reddit_password'))

--- a/reddit_scraper/sources.py
+++ b/reddit_scraper/sources.py
@@ -44,6 +44,35 @@ _rss_throttle_lock = threading.Lock()
 _rss_last_request = [0.0]
 RSS_MIN_INTERVAL = float(os.getenv('RSS_MIN_INTERVAL_SECONDS', '4'))
 
+# Optional proxying so the anonymous RSS/JSON endpoints aren't all hit from one IP
+# (the IP Reddit ends up flagging). REDDIT_PROXIES is a comma-separated pool rotated
+# per request; REDDIT_PROXY is a single proxy. Unset -> requests go out directly, so
+# this is a no-op until a proxy URL is provided. Supports http(s):// and socks5://
+# (socks needs `requests[socks]`). When any proxy is configured we NEVER fall back to a
+# direct request, so a configured IP-hiding setup can't silently leak the real IP.
+def _parse_proxies():
+    pool = os.getenv('REDDIT_PROXIES')
+    if pool:
+        return [p.strip() for p in pool.split(',') if p.strip()]
+    single = (os.getenv('REDDIT_PROXY') or '').strip()
+    return [single] if single else []
+
+_PROXIES = _parse_proxies()
+_proxy_index = [0]
+_proxy_cooldown_until = {}        # proxy url -> epoch time until which it is skipped
+_proxy_lock = threading.Lock()
+PROXY_COOLDOWN_SECONDS = int(os.getenv('PROXY_COOLDOWN_SECONDS', '120'))
+
+# Sylvia (api.sylvia-api.com) is a third-party Reddit gateway that returns native-Reddit-
+# shaped JSON from Sylvia's own IP (so it doubles as IP hiding) and, unlike RSS, carries
+# full post data (score/domain/flair). It's authenticated with an API key and is billed
+# per successful request, so it's OPT-IN: the 'sylvia' source is skipped entirely unless
+# SYLVIA_API_KEY is set, and it's not in the default source order.
+SYLVIA_API_KEY = os.getenv('SYLVIA_API_KEY')
+SYLVIA_BASE_URL = os.getenv('SYLVIA_BASE_URL', 'https://api.sylvia-api.com/v1/reddit').rstrip('/')
+SYLVIA_TIMEOUT = float(os.getenv('SYLVIA_TIMEOUT_SECONDS', '15'))
+_sylvia_key_warned = False       # so the "no key" skip is logged only once
+
 # Short-lived response cache so concurrent monitors covering the same subreddit/thread
 # share a single network request instead of each issuing its own (which both wastes
 # requests and trips rate limits). TTL only needs to span one scheduling burst.
@@ -81,6 +110,13 @@ def _reset_auth_error_notification():
 
 
 def _source_available(name):
+    if name == 'sylvia' and not SYLVIA_API_KEY:
+        global _sylvia_key_warned
+        with _source_state_lock:
+            if not _sylvia_key_warned:
+                logging.warning("Source 'sylvia' is in the order but SYLVIA_API_KEY is unset; skipping it.")
+                _sylvia_key_warned = True
+        return False
     with _source_state_lock:
         return time.time() >= _source_cooldown_until.get(name, 0)
 
@@ -147,11 +183,66 @@ def _rss_throttle():
         _rss_last_request[0] = time.time()
 
 
+def _redact_proxy(proxy):
+    """Hide any user:pass credentials in a proxy URL before it goes to a log."""
+    return re.sub(r'//[^@/]+@', '//***@', proxy)
+
+
+def _next_proxy():
+    """Round-robin the next proxy that isn't cooling down, or None if all are (or none set)."""
+    if not _PROXIES:
+        return None
+    now = time.time()
+    with _proxy_lock:
+        n = len(_PROXIES)
+        for _ in range(n):
+            i = _proxy_index[0] % n
+            _proxy_index[0] = (i + 1) % n
+            proxy = _PROXIES[i]
+            if _proxy_cooldown_until.get(proxy, 0) <= now:
+                return proxy
+        return None
+
+
+def _mark_proxy_down(proxy):
+    """Skip a proxy that failed to connect for a short while, then let it back in."""
+    with _proxy_lock:
+        _proxy_cooldown_until[proxy] = time.time() + PROXY_COOLDOWN_SECONDS
+
+
+def _http_get(url, headers, timeout=15):
+    """GET `url`, routed through a configured proxy when one is set.
+
+    With no proxy configured this is a plain requests.get. With a pool, requests are
+    rotated across proxies and a proxy that fails to *connect* is cooled down and the
+    next one tried. If proxies are configured but all are cooling down we raise rather
+    than fall back to a direct request, so IP hiding, once on, can't silently leak.
+    """
+    if not _PROXIES:
+        return requests.get(url, headers=headers, timeout=timeout)
+
+    last_err = None
+    for _ in range(len(_PROXIES)):
+        proxy = _next_proxy()
+        if proxy is None:
+            break
+        try:
+            return requests.get(url, headers=headers, timeout=timeout,
+                                 proxies={'http': proxy, 'https': proxy})
+        except (requests.exceptions.ProxyError,
+                requests.exceptions.ConnectTimeout,
+                requests.exceptions.ConnectionError) as e:
+            last_err = e
+            _mark_proxy_down(proxy)
+            logging.warning(f"Proxy {_redact_proxy(proxy)} failed to connect: {e}; trying next")
+    raise last_err or RuntimeError("All configured proxies are cooling down")
+
+
 def fetch_posts_json(subreddit, limit=10):
     """Fetch posts via the anonymous old.reddit.com JSON endpoint (mostly blocked now)."""
     url = f"https://old.reddit.com/r/{subreddit}/new.json?limit={limit}"
     try:
-        response = requests.get(url, headers={'User-Agent': JSON_USER_AGENT}, timeout=15)
+        response = _http_get(url, headers={'User-Agent': JSON_USER_AGENT})
         response.raise_for_status()
         data = response.json()
         posts = []
@@ -178,7 +269,7 @@ def fetch_thread_comments_json(subreddit, thread_id, limit=500):
     """Fetch top-level comments from a Reddit thread via the JSON endpoint, sorted by new."""
     url = f"https://old.reddit.com/r/{subreddit}/comments/{thread_id}.json?limit={limit}&sort=new"
     try:
-        response = requests.get(url, headers={'User-Agent': JSON_USER_AGENT}, timeout=15)
+        response = _http_get(url, headers={'User-Agent': JSON_USER_AGENT})
         response.raise_for_status()
         data = response.json()
 
@@ -204,13 +295,73 @@ def fetch_thread_comments_json(subreddit, thread_id, limit=500):
         return None
 
 
+def _sylvia_get(path):
+    """GET a Sylvia gateway path with the API key. Raises RuntimeError on auth (401/403)
+    and rate-limit (429) so the dispatcher cools the source down; raises for other HTTP
+    errors too. Returns the parsed JSON body."""
+    response = requests.get(f"{SYLVIA_BASE_URL}{path}",
+                            headers={'X-API-KEY': SYLVIA_API_KEY}, timeout=SYLVIA_TIMEOUT)
+    if response.status_code in (401, 403):
+        raise RuntimeError(f"Sylvia auth failed ({response.status_code}); check SYLVIA_API_KEY")
+    if response.status_code == 429:
+        raise RuntimeError("Sylvia rate limit hit (429)")
+    response.raise_for_status()
+    return response.json()
+
+
+def fetch_posts_sylvia(subreddit, limit=10):
+    """Fetch posts via the Sylvia Reddit gateway. Returns native-Reddit-shaped post data
+    (score/domain/flair all present), fetched from Sylvia's IP rather than ours. Paid per
+    request, so only reached when 'sylvia' is in the source order and SYLVIA_API_KEY is set."""
+    data = _sylvia_get(f"/r/{subreddit}/new?limit={limit}")
+    posts = []
+    for post_data in data.get('data', {}).get('posts', [])[:limit]:
+        posts.append({
+            'id': post_data.get('id', ''),
+            'title': post_data.get('title', ''),
+            'url': post_data.get('url', ''),
+            'score': post_data.get('score', 0),
+            'permalink': post_data.get('permalink', ''),
+            'domain': post_data.get('domain', ''),
+            'link_flair_text': post_data.get('link_flair_text') or '',
+            'author': post_data.get('author', ''),
+        })
+    record_fetch_success()
+    return posts
+
+
+def fetch_thread_comments_sylvia(subreddit, thread_id, limit=500):
+    """Fetch a thread's top-level comments via the Sylvia gateway. Its 'full_thread'
+    response mirrors Reddit's native [post_listing, comment_listing] pair, so we read the
+    t1 children of the second listing (same shape as fetch_thread_comments_json)."""
+    data = _sylvia_get(f"/submission/{thread_id}/full?sort=new")
+    thread = data.get('data', {}).get('thread', [])
+    if not isinstance(thread, list) or len(thread) < 2:
+        logging.error(f"Unexpected Sylvia thread structure for {thread_id}")
+        return None
+
+    comments = []
+    for child in thread[1].get('data', {}).get('children', []):
+        if child.get('kind') != 't1':
+            continue
+        d = child['data']
+        comments.append({
+            'id': d.get('id', ''),
+            'body': d.get('body', ''),
+            'author': d.get('author', ''),
+            'score': d.get('score', 0),
+            'permalink': d.get('permalink', ''),
+        })
+    return comments
+
+
 def fetch_posts_rss(subreddit, limit=10):
     """Fetch posts via the www.reddit.com Atom feed (no auth). Raises on 403/429 so the
     dispatcher can fall through and back off. Note: RSS exposes no score and no external
     domain, so those fields degrade to 0 / '' (score/domain filters won't match)."""
     _rss_throttle()
     url = f"https://www.reddit.com/r/{subreddit}/new/.rss?limit={limit}"
-    response = requests.get(url, headers={'User-Agent': RSS_USER_AGENT}, timeout=15)
+    response = _http_get(url, headers={'User-Agent': RSS_USER_AGENT})
     if response.status_code in (403, 429):
         raise RuntimeError(f"RSS blocked ({response.status_code})")
     response.raise_for_status()
@@ -251,7 +402,7 @@ def fetch_thread_comments_rss(subreddit, thread_id, limit=500):
     """Fetch a thread's comments via the www.reddit.com Atom feed (no auth)."""
     _rss_throttle()
     url = f"https://www.reddit.com/r/{subreddit}/comments/{thread_id}/.rss?sort=new&limit={limit}"
-    response = requests.get(url, headers={'User-Agent': RSS_USER_AGENT}, timeout=15)
+    response = _http_get(url, headers={'User-Agent': RSS_USER_AGENT})
     if response.status_code in (403, 429):
         raise RuntimeError(f"RSS blocked ({response.status_code})")
     response.raise_for_status()
@@ -324,6 +475,8 @@ def _fetch_posts_impl(subreddit, limit, reddit):
                 posts = fetch_posts_rss(subreddit, limit)
             elif source == 'json':
                 posts = fetch_posts_json(subreddit, limit)
+            elif source == 'sylvia':
+                posts = fetch_posts_sylvia(subreddit, limit)
             else:
                 continue
         except Exception as e:
@@ -384,6 +537,8 @@ def _fetch_thread_comments_impl(subreddit, thread_id, reddit):
                 comments = fetch_thread_comments_rss(subreddit, thread_id)
             elif source == 'json':
                 comments = fetch_thread_comments_json(subreddit, thread_id)
+            elif source == 'sylvia':
+                comments = fetch_thread_comments_sylvia(subreddit, thread_id)
             else:
                 continue
         except Exception as e:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -18,6 +18,11 @@ def reset_source_state():
     sources._rss_last_request[0] = 0.0
     sources.RSS_MIN_INTERVAL = 0
     sources.FETCH_CACHE_TTL = 0  # disable caching by default; coalescing tests opt back in
+    sources._PROXIES = []        # no proxy by default; proxy tests opt back in
+    sources._proxy_index[0] = 0
+    sources._proxy_cooldown_until.clear()
+    sources.SYLVIA_API_KEY = None   # sylvia disabled by default; its tests set a key
+    sources._sylvia_key_warned = False
     config.set_source_order(None)  # back to default oauth -> json -> rss
     yield
 
@@ -260,3 +265,168 @@ class TestBackoff:
     def test_explicit_seconds_does_not_increment_failures(self):
         sources._mark_source_down('rss', 50)
         assert sources._source_failures.get('rss', 0) == 0
+
+
+class TestProxying:
+
+    def _record_get(self, monkeypatch):
+        """Replace requests.get with a recorder returning a trivial 200 response."""
+        calls = []
+
+        class _Resp:
+            status_code = 200
+            content = POST_FEED
+            def raise_for_status(self): pass
+            def json(self): return {'data': {'children': []}}
+
+        def fake_get(url, headers=None, timeout=None, proxies=None):
+            calls.append(proxies)
+            return _Resp()
+
+        monkeypatch.setattr(sources.requests, 'get', fake_get)
+        return calls
+
+    def test_no_proxy_makes_direct_request(self, monkeypatch):
+        calls = self._record_get(monkeypatch)
+        sources.fetch_posts_rss('gamedeals')
+        assert calls == [None]                                  # proxies kwarg never passed
+
+    def test_single_proxy_is_used(self, monkeypatch):
+        calls = self._record_get(monkeypatch)
+        sources._PROXIES = ['http://proxy.local:8000']
+        sources.fetch_posts_rss('gamedeals')
+        assert calls == [{'http': 'http://proxy.local:8000',
+                          'https': 'http://proxy.local:8000'}]
+
+    def test_pool_rotates_across_requests(self, monkeypatch):
+        calls = self._record_get(monkeypatch)
+        sources._PROXIES = ['http://p1:8000', 'http://p2:8000']
+        sources.fetch_posts_rss('a')
+        sources.fetch_posts_rss('b')
+        sources.fetch_posts_rss('c')
+        used = [c['http'] for c in calls]
+        assert used == ['http://p1:8000', 'http://p2:8000', 'http://p1:8000']
+
+    def test_dead_proxy_is_skipped_and_next_tried(self, monkeypatch):
+        sources._PROXIES = ['http://dead:8000', 'http://good:8000']
+        attempts = []
+
+        class _Resp:
+            status_code = 200
+            content = POST_FEED
+            def raise_for_status(self): pass
+
+        def fake_get(url, headers=None, timeout=None, proxies=None):
+            attempts.append(proxies['http'])
+            if proxies['http'] == 'http://dead:8000':
+                raise sources.requests.exceptions.ProxyError("boom")
+            return _Resp()
+
+        monkeypatch.setattr(sources.requests, 'get', fake_get)
+        posts = sources.fetch_posts_rss('gamedeals')
+        assert attempts == ['http://dead:8000', 'http://good:8000']
+        assert 'http://dead:8000' in sources._proxy_cooldown_until   # cooled down
+        assert posts is not None
+
+    def test_all_proxies_down_raises_no_direct_leak(self, monkeypatch):
+        sources._PROXIES = ['http://p1:8000']
+
+        def fake_get(url, headers=None, timeout=None, proxies=None):
+            if proxies is None:
+                raise AssertionError("must never fall back to a direct request")
+            raise sources.requests.exceptions.ProxyError("down")
+
+        monkeypatch.setattr(sources.requests, 'get', fake_get)
+        with pytest.raises(sources.requests.exceptions.ProxyError):
+            sources.fetch_posts_rss('gamedeals')
+
+    def test_credentials_redacted_in_logs(self):
+        assert sources._redact_proxy('http://user:secret@host:8000') == 'http://***@host:8000'
+        assert sources._redact_proxy('socks5://127.0.0.1:9050') == 'socks5://127.0.0.1:9050'
+
+
+SYLVIA_POSTS = {
+    "success": True,
+    "data": {"after": "t3_zzz", "posts": [
+        {"id": "abc123", "title": "Red Dead Redemption 75% off",
+         "url": "https://store.example.com/x", "score": 42,
+         "permalink": "/r/gamedeals/comments/abc123/rdr/", "domain": "store.example.com",
+         "link_flair_text": None, "author": "dealhunter"},
+    ]},
+}
+
+SYLVIA_THREAD = {
+    "success": True,
+    "data": {"thread": [
+        {"data": {"children": [{"kind": "t3", "data": {"id": "abc123", "title": "the post"}}]}},
+        {"data": {"children": [
+            {"kind": "t1", "data": {"id": "def456", "body": "WTS shirt $20",
+                                    "author": "seller", "score": 3,
+                                    "permalink": "/r/x/comments/abc123/_/def456/"}},
+            {"kind": "more", "data": {"id": "ghi789"}},
+        ]}},
+    ]},
+}
+
+
+class TestSylvia:
+
+    BASE = 'https://api.sylvia-api.com/v1/reddit'
+
+    @responses.activate
+    def test_posts_parse_and_normalize(self):
+        sources.SYLVIA_API_KEY = 'syl_test'
+        responses.add(responses.GET, f'{self.BASE}/r/gamedeals/new', json=SYLVIA_POSTS, status=200)
+        posts = sources.fetch_posts_sylvia('gamedeals', limit=10)
+
+        assert len(posts) == 1
+        p = posts[0]
+        assert p['id'] == 'abc123'
+        assert p['score'] == 42                       # full data, unlike RSS
+        assert p['domain'] == 'store.example.com'
+        assert p['link_flair_text'] == ''             # None normalized to ''
+        # the key is sent in the X-API-KEY header
+        assert responses.calls[0].request.headers['X-API-KEY'] == 'syl_test'
+
+    @responses.activate
+    def test_comments_read_second_listing_t1_only(self):
+        sources.SYLVIA_API_KEY = 'syl_test'
+        responses.add(responses.GET, f'{self.BASE}/submission/abc123/full',
+                      json=SYLVIA_THREAD, status=200)
+        comments = sources.fetch_thread_comments_sylvia('x', 'abc123')
+
+        assert len(comments) == 1                     # 'more' child dropped, post listing ignored
+        assert comments[0]['id'] == 'def456'
+        assert comments[0]['author'] == 'seller'
+
+    @responses.activate
+    def test_auth_failure_raises_for_backoff(self):
+        sources.SYLVIA_API_KEY = 'syl_bad'
+        responses.add(responses.GET, f'{self.BASE}/r/gamedeals/new',
+                      json={"error": {"code": "FORBIDDEN"}}, status=403)
+        with pytest.raises(RuntimeError):
+            sources.fetch_posts_sylvia('gamedeals')
+
+    @responses.activate
+    def test_rate_limit_raises_for_backoff(self):
+        sources.SYLVIA_API_KEY = 'syl_test'
+        responses.add(responses.GET, f'{self.BASE}/r/gamedeals/new', status=429)
+        with pytest.raises(RuntimeError):
+            sources.fetch_posts_sylvia('gamedeals')
+
+    def test_source_skipped_when_no_key(self):
+        sources.SYLVIA_API_KEY = None
+        config.set_source_order(['sylvia'])           # only sylvia, but no key
+        posts, source = sources.fetch_posts('gamedeals', 10, reddit=None)
+        assert (posts, source) == (None, None)        # skipped, never requested
+
+    @responses.activate
+    def test_dispatcher_uses_sylvia_when_ordered_and_keyed(self, monkeypatch):
+        sources.SYLVIA_API_KEY = 'syl_test'
+        config.set_source_order(['sylvia', 'json'])
+        responses.add(responses.GET, f'{self.BASE}/r/gamedeals/new', json=SYLVIA_POSTS, status=200)
+        # json must not be reached if sylvia succeeds
+        monkeypatch.setattr(sources, 'fetch_posts_json',
+                            lambda *a, **k: pytest.fail("json should not be called"))
+        posts, source = sources.fetch_posts('gamedeals', 10, reddit=None)
+        assert source == 'sylvia' and posts[0]['id'] == 'abc123'


### PR DESCRIPTION
## Summary

Expands and hardens the Reddit data-source layer with two additions, both aimed at surviving a flagged/blocked IP on the anonymous (RSS/JSON) pathways.

### 1. Proxy support (IP hiding)
- Routes the anonymous RSS/JSON requests through an optional proxy (`REDDIT_PROXY`) or rotated pool (`REDDIT_PROXIES`) via a single `_http_get` helper.
- A pooled proxy that fails to connect is cooled down and the next is tried.
- Once any proxy is configured we **never** fall back to a direct request, so an IP-hiding setup can't silently leak the real IP.
- Complete no-op when unset — no behavior change by default.

### 2. Sylvia gateway (`api.sylvia-api.com`) as a new `sylvia` source
- Returns full native-Reddit-shaped post/comment data from Sylvia's own IP (carries `score`/`domain`/`flair`, unlike RSS).
- Wired into both dispatchers with the existing backoff/coalescing.
- **Paid + key-gated, so opt-in**: skipped entirely unless `SYLVIA_API_KEY` is set, and left out of the default source order. Auth `403` / rate-limit `429` raise so the source backs off cleanly.

### 3. UI key entry
- Enter the Sylvia key from the settings UI / credentials file, not just the env var.
- Masked on GET, skipped-if-masked on PUT; bridged into the sources layer on startup.

## Commits
- `backend source layer` — proxy + Sylvia source (`.env.example`, `config.py`, `sources.py`, `test_sources.py`)
- `UI key entry` — masked field + credential bridge (`api.py`, `credentials.py`, `SettingsModal.tsx`)

The env-var path works from the first commit alone; the second adds file/UI-based key entry on top.

## Testing
- `92 passed` (added proxy rotation/cooldown + Sylvia parsing/gating coverage)
- Frontend TypeScript clean
- Verified end-to-end: a stored key flows through `detect_auth_capability` into `sources`, gates the source on/off, and masks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)