### PR TITLE
Sylvia data-source picker, live credential reload, and codebase cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,104 @@
+# CLAUDE.md
+
+Guidance for working in this repo. It documents the conventions the code already
+follows so changes stay consistent rather than ad hoc.
+
+## What this is
+
+A Reddit monitor that watches subreddits/threads for keyword matches and sends push
+notifications. Three deployable pieces (see `docker-compose.yml`):
+
+- **`bot.py`** — the long-running monitor loop (`python bot.py`). Fetches posts/comments,
+  applies filters, sends notifications. Hot-reloads `search.json` and `credentials.json`.
+- **`api.py`** — a Flask REST API (`python api.py`, port 5001) backing the web UI. Reads/
+  writes `search.json` (monitors + source order) and `credentials.json`.
+- **`frontend/`** — a Next.js web UI (`npm run dev`).
+
+The reusable logic lives in the **`reddit_scraper/`** package; `api.py` and `bot.py` are
+thin entry points that compose it.
+
+### `reddit_scraper/` modules
+
+| Module | Responsibility |
+|--------|----------------|
+| `config.py` | Data paths (`DATA_DIR`), `search.json` access, source-order resolution. **The single source of truth for `VALID_SOURCES` / `DEFAULT_SOURCE_ORDER`** — reference these, don't hardcode source lists. |
+| `credentials.py` | Credential loading (file + env), the non-ASCII encoding guard, PRAW auth. |
+| `sources.py` | The data-source pathways (`oauth`/`sylvia`/`json`/`rss`) and the fetch dispatcher. Runtime state is encapsulated in `_SourceState` (see below). |
+| `monitor.py` | `RedditMonitor` — evaluates a subreddit/thread against filter rules. |
+| `notifications.py` | Apprise dispatch. |
+| `status.py` / `health.py` | Bot-status file + Uptime Kuma heartbeats. |
+
+## Commands
+
+```bash
+python3 -m pytest -q            # run the test suite (fast, no network — HTTP is mocked)
+python3 -m ruff check .         # lint
+python3 -m ruff format .        # auto-format
+python3 -m ruff check . --fix   # lint + autofix
+```
+
+Frontend: `npm run lint` / `npm run build` in `frontend/`.
+
+**Before committing Python changes, run `ruff check .` and `ruff format .`.** Config is in
+`ruff.toml` (E/W/F/I, line-length 120, `quote-style = preserve`). Ruff is in
+`requirements-test.txt`.
+
+## Coding principles
+
+### Python
+
+- **Style is enforced by ruff** — don't hand-format; run `ruff format`. Line length 120.
+- **snake_case** functions/variables, **PascalCase** classes. Module-level "private" helpers
+  are prefixed `_`.
+- **No type annotations** — this codebase deliberately doesn't use them. Convey types through
+  clear names and docstrings; don't add hints piecemeal.
+- **Logging, not print** — use the `logging` module with **f-string** messages
+  (`logging.info(f"...")`). Emoji prefixes are used for scannable status lines (📡 🔐 ⚠️).
+  `print` is only for a CLI startup banner in `__main__`.
+- **Docstrings explain _why_, not _what_** — a one-liner for simple functions; for non-obvious
+  logic, say what problem it solves (see `_SourceState`, `_coalesce`). Keep them concise.
+- **Centralize shared access** — paths/config through `config.py`, credentials through
+  `credentials.py`. Don't re-read env vars or files that a helper already owns.
+
+### Error handling
+
+- **Fetchers signal blocking by raising, transient/empty by returning `None`.** RSS/JSON/Sylvia
+  fetchers `raise` on 403/429/auth failure so the dispatcher cools the source down and falls
+  through; they return `None` on a malformed-but-non-blocking response.
+- **Broad `except Exception` belongs at boundaries** — the fetch dispatcher, the monitor loop,
+  and Flask routes catch broadly to degrade gracefully (log + continue / return an error JSON).
+  Elsewhere, catch the specific exception you expect.
+- **Fail safe.** When a source can't provide a field (e.g. RSS has no score/domain), filters
+  that need it don't match rather than firing false notifications.
+
+### State
+
+- **`sources.py` runtime state lives in `_SourceState`** (cooldowns/backoff, active source,
+  coalescing cache, proxy rotation, RSS throttle, notification flags), owned by a single
+  `_state` instance. Module-level functions are a thin facade over it — call those (and the
+  `get_active_source()` / `get_last_fetch_success_ts()` accessors) rather than reaching into
+  fields. Tuning knobs (`SOURCE_COOLDOWN_*`, `FETCH_CACHE_TTL`, `_PROXIES`, `SYLVIA_API_KEY`,
+  …) stay module-level config so they can be overridden by env/tests.
+
+### Data sources
+
+The dispatcher tries sources in `config.get_source_order()`, falling through on failure with
+exponential backoff, and coalesces duplicate concurrent fetches. Order is set via the UI
+(→ `search.json`), then `REDDIT_SOURCE_ORDER`, then the default. `sylvia` is opt-in (needs
+`SYLVIA_API_KEY`); anonymous fetches can be routed through a proxy (`REDDIT_PROXY(IES)`).
+
+### Frontend
+
+- **PascalCase components**, one concern each. Large modals are split into focused sections
+  (see `components/settings/`), with shared types in a co-located `types.ts`.
+- Lint with the repo `eslint.config.mjs`.
+
+## Testing
+
+- **pytest**, one `test_<module>.py` per module under `tests/`; shared setup in `conftest.py`.
+- **No network in tests** — HTTP is mocked with `responses` (or by monkeypatching `requests`).
+- **Reset module/global state in an `autouse` fixture** (see `test_sources.py`'s
+  `reset_source_state`, which calls `sources._state.reset()`).
+- **Test through the public surface** — call the public functions/accessors, not private
+  state, so tests survive internal refactors.
+- Add/adjust tests with any behavior change; keep the suite green.

--- a/REDDIT_API_APPLICATION.md
+++ b/REDDIT_API_APPLICATION.md
@@ -167,7 +167,7 @@ return praw.Reddit(
     client_secret=client_secret,
     user_agent=user_agent,  # e.g., "RedditMonitor/1.0 by /u/username"
     username=username,
-    password=password
+    password=password,
 )
 ```
 

--- a/api.py
+++ b/api.py
@@ -65,11 +65,15 @@ def get_source_capability():
     client_secret = creds.get('reddit_client_secret') or os.getenv('REDDIT_CLIENT_SECRET')
     oauth_available = bool(client_id and client_secret) and 'oauth' in order
 
+    sylvia_key = creds.get('sylvia_api_key') or os.getenv('SYLVIA_API_KEY')
+    sylvia_available = bool(sylvia_key) and 'sylvia' in order
+
     return {
         'source_order': order,
         'oauth_available': oauth_available,
-        # score and domain are only available through the authenticated API
-        'rich_filters_supported': oauth_available,
+        # score/domain need a full-data source: the authenticated API or the Sylvia
+        # gateway both expose them; RSS does not (so filters can't be applied there).
+        'rich_filters_supported': oauth_available or sylvia_available,
     }
 
 

--- a/api.py
+++ b/api.py
@@ -51,14 +51,14 @@ def get_source_capability():
     """Report which data-source pathways are configured and whether the OAuth API
     (required for score/domain filters) is available. Used by the UI to hide filters
     that the active pathways can't provide."""
-    valid = ('oauth', 'rss', 'json', 'sylvia')
+    default_order = rs_config.DEFAULT_SOURCE_ORDER
     try:
         config = load_config() or {}
     except Exception:
         config = {}
-    order = [s for s in (config.get('source_order') or ['oauth', 'rss', 'json']) if s in valid]
+    order = [s for s in (config.get('source_order') or default_order) if s in rs_config.VALID_SOURCES]
     if not order:
-        order = ['oauth', 'rss', 'json']
+        order = list(default_order)
 
     creds = load_credentials()
     client_id = creds.get('reddit_client_id') or os.getenv('REDDIT_CLIENT_ID')

--- a/api.py
+++ b/api.py
@@ -51,7 +51,7 @@ def get_source_capability():
     """Report which data-source pathways are configured and whether the OAuth API
     (required for score/domain filters) is available. Used by the UI to hide filters
     that the active pathways can't provide."""
-    valid = ('oauth', 'rss', 'json')
+    valid = ('oauth', 'rss', 'json', 'sylvia')
     try:
         config = load_config() or {}
     except Exception:
@@ -483,6 +483,46 @@ def update_credentials():
             'configured': is_configured(),
             'notification_count': len(creds.get('notification_urls', []))
         })
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+
+# Which data source the UI dropdown selects, mapped to the bot's source order.
+# The free json/rss pathways are kept as a last-ditch fallback behind the chosen
+# primary so a blocked primary still degrades gracefully rather than going dark.
+SOURCE_PRESETS = {
+    'reddit': ['oauth', 'json', 'rss'],
+    'sylvia': ['sylvia', 'json', 'rss'],
+}
+
+
+@app.route('/api/source-order', methods=['GET'])
+def get_source_order():
+    """Report the active data source (derived from the primary of the saved source order)."""
+    try:
+        config = load_config() or {}
+    except Exception:
+        config = {}
+    order = config.get('source_order') or []
+    active = 'sylvia' if order and order[0] == 'sylvia' else 'reddit'
+    return jsonify({'active_source': active, 'source_order': order})
+
+
+@app.route('/api/source-order', methods=['PUT'])
+def update_source_order():
+    """Set the active data source. Writes source_order into search.json; the bot
+    hot-reloads that file, so the change takes effect without a restart."""
+    try:
+        data = request.get_json() or {}
+        active = data.get('active_source')
+        if active not in SOURCE_PRESETS:
+            return jsonify({'error': f"active_source must be one of {list(SOURCE_PRESETS)}"}), 400
+
+        config = load_config() or {}
+        config['source_order'] = SOURCE_PRESETS[active]
+        save_config(config)
+        return jsonify({'success': True, 'active_source': active,
+                        'source_order': SOURCE_PRESETS[active]})
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 

--- a/api.py
+++ b/api.py
@@ -43,11 +43,7 @@ def save_config(config):
 @app.route('/api/health', methods=['GET'])
 def health_check():
     """Health check endpoint."""
-    return jsonify({
-        'status': 'ok',
-        'timestamp': datetime.now().isoformat(),
-        'config_path': CONFIG_FILE_PATH
-    })
+    return jsonify({'status': 'ok', 'timestamp': datetime.now().isoformat(), 'config_path': CONFIG_FILE_PATH})
 
 
 def get_source_capability():
@@ -111,9 +107,7 @@ def search_subreddits():
         # Use Reddit's search API
         headers = {'User-Agent': 'RedditMonitorWebUI/1.0'}
         response = requests.get(
-            f'https://www.reddit.com/subreddits/search.json?q={query}&limit=10',
-            headers=headers,
-            timeout=5
+            f'https://www.reddit.com/subreddits/search.json?q={query}&limit=10', headers=headers, timeout=5
         )
 
         if response.status_code == 200:
@@ -121,12 +115,14 @@ def search_subreddits():
             subreddits = []
             for child in data.get('data', {}).get('children', []):
                 sub_data = child.get('data', {})
-                subreddits.append({
-                    'name': sub_data.get('display_name', ''),
-                    'title': sub_data.get('title', ''),
-                    'subscribers': sub_data.get('subscribers', 0),
-                    'public_description': sub_data.get('public_description', '')[:100]
-                })
+                subreddits.append(
+                    {
+                        'name': sub_data.get('display_name', ''),
+                        'title': sub_data.get('title', ''),
+                        'subscribers': sub_data.get('subscribers', 0),
+                        'public_description': sub_data.get('public_description', '')[:100],
+                    }
+                )
             return jsonify({'subreddits': subreddits})
         else:
             return jsonify({'subreddits': [], 'error': 'Reddit API error'})
@@ -142,24 +138,22 @@ def validate_subreddit(subreddit_name):
 
     try:
         headers = {'User-Agent': 'RedditMonitorWebUI/1.0'}
-        response = requests.get(
-            f'https://www.reddit.com/r/{subreddit_name}/about.json',
-            headers=headers,
-            timeout=5
-        )
+        response = requests.get(f'https://www.reddit.com/r/{subreddit_name}/about.json', headers=headers, timeout=5)
 
         if response.status_code == 200:
             data = response.json()
             sub_data = data.get('data', {})
             # Check if it's a valid subreddit (has required fields)
             if sub_data.get('display_name'):
-                return jsonify({
-                    'valid': True,
-                    'name': sub_data.get('display_name'),
-                    'title': sub_data.get('title', ''),
-                    'subscribers': sub_data.get('subscribers', 0),
-                    'nsfw': sub_data.get('over18', False)
-                })
+                return jsonify(
+                    {
+                        'valid': True,
+                        'name': sub_data.get('display_name'),
+                        'title': sub_data.get('title', ''),
+                        'subscribers': sub_data.get('subscribers', 0),
+                        'nsfw': sub_data.get('over18', False),
+                    }
+                )
 
         # Subreddit doesn't exist or is private
         return jsonify({'valid': False, 'error': 'Subreddit not found'})
@@ -173,9 +167,7 @@ def get_monitors():
     """Get all monitors."""
     try:
         config = load_config()
-        return jsonify({
-            'monitors': config.get('subreddits_to_search', [])
-        })
+        return jsonify({'monitors': config.get('subreddits_to_search', [])})
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 
@@ -211,7 +203,7 @@ def create_monitor():
             'domain_excludes': data.get('domain_excludes', []),
             'flair_contains': data.get('flair_contains', []),
             'author_includes': data.get('author_includes', []),
-            'author_excludes': data.get('author_excludes', [])
+            'author_excludes': data.get('author_excludes', []),
         }
 
         clean_monitor(new_monitor)
@@ -341,14 +333,16 @@ def get_credentials_status():
     """Check if credentials are configured (without exposing them)."""
     creds = load_credentials()
     notification_urls = creds.get('notification_urls', [])
-    return jsonify({
-        'configured': is_configured(),
-        'has_reddit': bool(creds.get('reddit_client_id') and creds.get('reddit_client_secret')),
-        'has_notifications': len(notification_urls) > 0,
-        'notification_count': len(notification_urls),
-        'has_reddit_username': bool(creds.get('reddit_username')),
-        'has_sylvia': bool(creds.get('sylvia_api_key')),
-    })
+    return jsonify(
+        {
+            'configured': is_configured(),
+            'has_reddit': bool(creds.get('reddit_client_id') and creds.get('reddit_client_secret')),
+            'has_notifications': len(notification_urls) > 0,
+            'notification_count': len(notification_urls),
+            'has_reddit_username': bool(creds.get('reddit_username')),
+            'has_sylvia': bool(creds.get('sylvia_api_key')),
+        }
+    )
 
 
 @app.route('/api/credentials', methods=['GET'])
@@ -367,16 +361,18 @@ def get_credentials():
         else:
             masked_urls.append('••••••••')
 
-    return jsonify({
-        'reddit_client_id': mask_value(creds.get('reddit_client_id', '')),
-        'reddit_client_secret': mask_value(creds.get('reddit_client_secret', '')),
-        'reddit_username': creds.get('reddit_username', ''),
-        'reddit_password': mask_value(creds.get('reddit_password', '')),
-        'reddit_user_agent': creds.get('reddit_user_agent', ''),
-        'sylvia_api_key': mask_value(creds.get('sylvia_api_key', '')),
-        'notification_urls': notification_urls,  # Return full URLs for editing
-        'notification_urls_masked': masked_urls,  # Masked for display
-    })
+    return jsonify(
+        {
+            'reddit_client_id': mask_value(creds.get('reddit_client_id', '')),
+            'reddit_client_secret': mask_value(creds.get('reddit_client_secret', '')),
+            'reddit_username': creds.get('reddit_username', ''),
+            'reddit_password': mask_value(creds.get('reddit_password', '')),
+            'reddit_user_agent': creds.get('reddit_user_agent', ''),
+            'sylvia_api_key': mask_value(creds.get('sylvia_api_key', '')),
+            'notification_urls': notification_urls,  # Return full URLs for editing
+            'notification_urls_masked': masked_urls,  # Masked for display
+        }
+    )
 
 
 def mask_value(value):
@@ -404,28 +400,28 @@ def validate_reddit_credentials(client_id, client_secret, username, password, us
     Returns (success: bool, error_message: str or None)
     """
     # First, check for non-ASCII characters
-    for name, value in [('client_id', client_id), ('client_secret', client_secret),
-                        ('username', username), ('password', password), ('user_agent', user_agent)]:
+    for name, value in [
+        ('client_id', client_id),
+        ('client_secret', client_secret),
+        ('username', username),
+        ('password', password),
+        ('user_agent', user_agent),
+    ]:
         non_ascii = rs_credentials.find_non_ascii(value)
         if non_ascii:
             i, c = non_ascii[0]
-            return False, f"Non-ASCII character found in {name} at position {i}: '{c}' ({hex(ord(c))}). Please re-type the credential."
+            return (
+                False,
+                f"Non-ASCII character found in {name} at position {i}: '{c}' ({hex(ord(c))}). Please re-type the credential.",
+            )
 
     # Try to authenticate with Reddit
     try:
         auth = requests.auth.HTTPBasicAuth(client_id, client_secret)
         headers = {'User-Agent': user_agent}
-        data = {
-            'grant_type': 'password',
-            'username': username,
-            'password': password
-        }
+        data = {'grant_type': 'password', 'username': username, 'password': password}
         response = requests.post(
-            'https://www.reddit.com/api/v1/access_token',
-            auth=auth,
-            headers=headers,
-            data=data,
-            timeout=10
+            'https://www.reddit.com/api/v1/access_token', auth=auth, headers=headers, data=data, timeout=10
         )
 
         if response.status_code == 200:
@@ -462,8 +458,14 @@ def update_credentials():
         creds = load_credentials()
 
         # Only update fields that are provided and not masked
-        fields = ['reddit_client_id', 'reddit_client_secret', 'reddit_username',
-                  'reddit_password', 'reddit_user_agent', 'sylvia_api_key']
+        fields = [
+            'reddit_client_id',
+            'reddit_client_secret',
+            'reddit_username',
+            'reddit_password',
+            'reddit_user_agent',
+            'sylvia_api_key',
+        ]
 
         for field in fields:
             if field in data and not is_masked(data[field]):
@@ -483,22 +485,20 @@ def update_credentials():
                 creds.get('reddit_client_secret', ''),
                 creds.get('reddit_username', ''),
                 creds.get('reddit_password', ''),
-                creds.get('reddit_user_agent', 'RedditMonitor/1.0')
+                creds.get('reddit_user_agent', 'RedditMonitor/1.0'),
             )
             if not valid:
-                return jsonify({
-                    'success': False,
-                    'error': error,
-                    'validation_failed': True
-                }), 400
+                return jsonify({'success': False, 'error': error, 'validation_failed': True}), 400
 
         save_credentials(creds)
 
-        return jsonify({
-            'success': True,
-            'configured': is_configured(),
-            'notification_count': len(creds.get('notification_urls', []))
-        })
+        return jsonify(
+            {
+                'success': True,
+                'configured': is_configured(),
+                'notification_count': len(creds.get('notification_urls', [])),
+            }
+        )
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 
@@ -537,8 +537,7 @@ def update_source_order():
         config = load_config() or {}
         config['source_order'] = SOURCE_PRESETS[active]
         save_config(config)
-        return jsonify({'success': True, 'active_source': active,
-                        'source_order': SOURCE_PRESETS[active]})
+        return jsonify({'success': True, 'active_source': active, 'source_order': SOURCE_PRESETS[active]})
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 
@@ -558,17 +557,11 @@ def test_reddit_credentials():
         user_agent = data.get('reddit_user_agent') or creds.get('reddit_user_agent', 'RedditMonitor/1.0')
 
         if not all([client_id, client_secret, username, password]):
-            return jsonify({
-                'success': False,
-                'error': 'Missing required Reddit credentials'
-            }), 400
+            return jsonify({'success': False, 'error': 'Missing required Reddit credentials'}), 400
 
         valid, error = validate_reddit_credentials(client_id, client_secret, username, password, user_agent)
 
-        return jsonify({
-            'success': valid,
-            'error': error
-        })
+        return jsonify({'success': valid, 'error': error})
     except Exception as e:
         return jsonify({'success': False, 'error': str(e)}), 500
 
@@ -581,10 +574,7 @@ def test_notification():
         notification_urls = creds.get('notification_urls', [])
 
         if not notification_urls:
-            return jsonify({
-                'success': False,
-                'error': 'No notification services configured'
-            }), 400
+            return jsonify({'success': False, 'error': 'No notification services configured'}), 400
 
         # Create Apprise instance and add all URLs
         apobj = apprise.Apprise()
@@ -594,17 +584,18 @@ def test_notification():
         # Send test notification
         result = apobj.notify(
             body="This is a test notification from Reddit Monitor. If you see this, notifications are working! 🎉",
-            title="🧪 Test Notification"
+            title="🧪 Test Notification",
         )
 
-        return jsonify({
-            'success': result,
-            'services_count': len(notification_urls),
-            'message': 'Test notification sent!' if result else 'Some notifications may have failed'
-        })
+        return jsonify(
+            {
+                'success': result,
+                'services_count': len(notification_urls),
+                'message': 'Test notification sent!' if result else 'Some notifications may have failed',
+            }
+        )
     except Exception as e:
         return jsonify({'error': str(e)}), 500
-
 
 
 if __name__ == '__main__':

--- a/api.py
+++ b/api.py
@@ -383,18 +383,30 @@ def mask_value(value):
     return value[:4] + '••••••••'
 
 
+def is_masked(value):
+    """True if value is empty or a masked placeholder, so it must not overwrite stored data."""
+    return not value or '••••' in value
+
+
+def resolve_credential(data, creds, key):
+    """Pick an incoming credential value, falling back to the stored one when the incoming
+    value is missing or still masked (the UI sends masked placeholders for untouched fields)."""
+    incoming = data.get(key)
+    return incoming if not is_masked(incoming) else creds.get(key, '')
+
+
 def validate_reddit_credentials(client_id, client_secret, username, password, user_agent):
     """Validate Reddit API credentials by attempting authentication.
     
     Returns (success: bool, error_message: str or None)
     """
     # First, check for non-ASCII characters
-    for name, value in [('client_id', client_id), ('client_secret', client_secret), 
+    for name, value in [('client_id', client_id), ('client_secret', client_secret),
                         ('username', username), ('password', password), ('user_agent', user_agent)]:
-        if value:
-            non_ascii = [(i, c, hex(ord(c))) for i, c in enumerate(value) if ord(c) > 127]
-            if non_ascii:
-                return False, f"Non-ASCII character found in {name} at position {non_ascii[0][0]}: '{non_ascii[0][1]}' ({non_ascii[0][2]}). Please re-type the credential."
+        non_ascii = rs_credentials.find_non_ascii(value)
+        if non_ascii:
+            i, c = non_ascii[0]
+            return False, f"Non-ASCII character found in {name} at position {i}: '{c}' ({hex(ord(c))}). Please re-type the credential."
     
     # Try to authenticate with Reddit
     try:
@@ -451,11 +463,8 @@ def update_credentials():
                   'reddit_password', 'reddit_user_agent', 'sylvia_api_key']
         
         for field in fields:
-            if field in data:
-                value = data[field]
-                # Don't save masked values
-                if value and '••••' not in value:
-                    creds[field] = value
+            if field in data and not is_masked(data[field]):
+                creds[field] = data[field]
         
         # Handle notification_urls array
         if 'notification_urls' in data:
@@ -538,11 +547,11 @@ def test_reddit_credentials():
         data = request.get_json()
         creds = load_credentials()
         
-        # Use provided values or fall back to stored ones
-        client_id = data.get('reddit_client_id') if data.get('reddit_client_id') and '••••' not in data.get('reddit_client_id', '') else creds.get('reddit_client_id', '')
-        client_secret = data.get('reddit_client_secret') if data.get('reddit_client_secret') and '••••' not in data.get('reddit_client_secret', '') else creds.get('reddit_client_secret', '')
-        username = data.get('reddit_username') if data.get('reddit_username') and '••••' not in data.get('reddit_username', '') else creds.get('reddit_username', '')
-        password = data.get('reddit_password') if data.get('reddit_password') and '••••' not in data.get('reddit_password', '') else creds.get('reddit_password', '')
+        # Use provided values or fall back to stored ones (masked = untouched)
+        client_id = resolve_credential(data, creds, 'reddit_client_id')
+        client_secret = resolve_credential(data, creds, 'reddit_client_secret')
+        username = resolve_credential(data, creds, 'reddit_username')
+        password = resolve_credential(data, creds, 'reddit_password')
         user_agent = data.get('reddit_user_agent') or creds.get('reddit_user_agent', 'RedditMonitor/1.0')
         
         if not all([client_id, client_secret, username, password]):

--- a/api.py
+++ b/api.py
@@ -3,16 +3,19 @@ Flask API for Reddit Monitor Web UI
 Provides REST endpoints to manage search.json configuration
 """
 
-from flask import Flask, jsonify, request
-from flask_cors import CORS
 import json
+import logging
 import os
 import uuid
-import requests
 from datetime import datetime
-import apprise
 
-from reddit_scraper import config as rs_config, credentials as rs_credentials
+import apprise
+import requests
+from flask import Flask, jsonify, request
+from flask_cors import CORS
+
+from reddit_scraper import config as rs_config
+from reddit_scraper import credentials as rs_credentials
 
 app = Flask(__name__)
 CORS(app)  # Enable CORS for all routes
@@ -100,10 +103,10 @@ def bot_status():
 def search_subreddits():
     """Search for subreddits using Reddit's API."""
     query = request.args.get('q', '').strip()
-    
+
     if not query or len(query) < 2:
         return jsonify({'subreddits': []})
-    
+
     try:
         # Use Reddit's search API
         headers = {'User-Agent': 'RedditMonitorWebUI/1.0'}
@@ -112,7 +115,7 @@ def search_subreddits():
             headers=headers,
             timeout=5
         )
-        
+
         if response.status_code == 200:
             data = response.json()
             subreddits = []
@@ -136,7 +139,7 @@ def validate_subreddit(subreddit_name):
     """Validate that a subreddit exists."""
     if not subreddit_name or len(subreddit_name) < 2:
         return jsonify({'valid': False, 'error': 'Subreddit name too short'})
-    
+
     try:
         headers = {'User-Agent': 'RedditMonitorWebUI/1.0'}
         response = requests.get(
@@ -144,7 +147,7 @@ def validate_subreddit(subreddit_name):
             headers=headers,
             timeout=5
         )
-        
+
         if response.status_code == 200:
             data = response.json()
             sub_data = data.get('data', {})
@@ -157,7 +160,7 @@ def validate_subreddit(subreddit_name):
                     'subscribers': sub_data.get('subscribers', 0),
                     'nsfw': sub_data.get('over18', False)
                 })
-        
+
         # Subreddit doesn't exist or is private
         return jsonify({'valid': False, 'error': 'Subreddit not found'})
     except Exception as e:
@@ -182,16 +185,16 @@ def create_monitor():
     """Create a new monitor."""
     try:
         data = request.get_json()
-        
+
         if not data:
             return jsonify({'error': 'No data provided'}), 400
-        
+
         if not data.get('subreddit'):
             return jsonify({'error': 'Subreddit is required'}), 400
-        
+
         config = load_config()
         monitors = config.get('subreddits_to_search', [])
-        
+
         # Create new monitor with defaults
         new_monitor = {
             'id': str(uuid.uuid4()),
@@ -210,7 +213,7 @@ def create_monitor():
             'author_includes': data.get('author_includes', []),
             'author_excludes': data.get('author_excludes', [])
         }
-        
+
         clean_monitor(new_monitor)
         monitors.append(new_monitor)
         config['subreddits_to_search'] = monitors
@@ -227,11 +230,11 @@ def get_monitor(monitor_id):
     try:
         config = load_config()
         monitors = config.get('subreddits_to_search', [])
-        
+
         for monitor in monitors:
             if monitor.get('id') == monitor_id:
                 return jsonify(monitor)
-        
+
         return jsonify({'error': 'Monitor not found'}), 404
     except Exception as e:
         return jsonify({'error': str(e)}), 500
@@ -242,13 +245,13 @@ def update_monitor(monitor_id):
     """Update an existing monitor."""
     try:
         data = request.get_json()
-        
+
         if not data:
             return jsonify({'error': 'No data provided'}), 400
-        
+
         config = load_config()
         monitors = config.get('subreddits_to_search', [])
-        
+
         for i, monitor in enumerate(monitors):
             if monitor.get('id') == monitor_id:
                 # Update fields
@@ -281,13 +284,13 @@ def update_monitor(monitor_id):
                     monitors[i]['author_includes'] = data['author_includes']
                 if 'author_excludes' in data:
                     monitors[i]['author_excludes'] = data['author_excludes']
-                
+
                 clean_monitor(monitors[i])
                 config['subreddits_to_search'] = monitors
                 save_config(config)
 
                 return jsonify(monitors[i])
-        
+
         return jsonify({'error': 'Monitor not found'}), 404
     except Exception as e:
         return jsonify({'error': str(e)}), 500
@@ -299,14 +302,14 @@ def delete_monitor(monitor_id):
     try:
         config = load_config()
         monitors = config.get('subreddits_to_search', [])
-        
+
         for i, monitor in enumerate(monitors):
             if monitor.get('id') == monitor_id:
                 deleted = monitors.pop(i)
                 config['subreddits_to_search'] = monitors
                 save_config(config)
                 return jsonify({'deleted': deleted})
-        
+
         return jsonify({'error': 'Monitor not found'}), 404
     except Exception as e:
         return jsonify({'error': str(e)}), 500
@@ -353,7 +356,7 @@ def get_credentials():
     """Get credentials (masked for security)."""
     creds = load_credentials()
     notification_urls = creds.get('notification_urls', [])
-    
+
     # Mask notification URLs (show service type but hide tokens)
     masked_urls = []
     for url in notification_urls:
@@ -363,7 +366,7 @@ def get_credentials():
             masked_urls.append(f"{protocol}://••••••••")
         else:
             masked_urls.append('••••••••')
-    
+
     return jsonify({
         'reddit_client_id': mask_value(creds.get('reddit_client_id', '')),
         'reddit_client_secret': mask_value(creds.get('reddit_client_secret', '')),
@@ -397,7 +400,7 @@ def resolve_credential(data, creds, key):
 
 def validate_reddit_credentials(client_id, client_secret, username, password, user_agent):
     """Validate Reddit API credentials by attempting authentication.
-    
+
     Returns (success: bool, error_message: str or None)
     """
     # First, check for non-ASCII characters
@@ -407,7 +410,7 @@ def validate_reddit_credentials(client_id, client_secret, username, password, us
         if non_ascii:
             i, c = non_ascii[0]
             return False, f"Non-ASCII character found in {name} at position {i}: '{c}' ({hex(ord(c))}). Please re-type the credential."
-    
+
     # Try to authenticate with Reddit
     try:
         auth = requests.auth.HTTPBasicAuth(client_id, client_secret)
@@ -424,7 +427,7 @@ def validate_reddit_credentials(client_id, client_secret, username, password, us
             data=data,
             timeout=10
         )
-        
+
         if response.status_code == 200:
             result = response.json()
             if 'access_token' in result:
@@ -455,23 +458,23 @@ def update_credentials():
         data = request.get_json()
         if not data:
             return jsonify({'error': 'No data provided'}), 400
-        
+
         creds = load_credentials()
-        
+
         # Only update fields that are provided and not masked
         fields = ['reddit_client_id', 'reddit_client_secret', 'reddit_username',
                   'reddit_password', 'reddit_user_agent', 'sylvia_api_key']
-        
+
         for field in fields:
             if field in data and not is_masked(data[field]):
                 creds[field] = data[field]
-        
+
         # Handle notification_urls array
         if 'notification_urls' in data:
             # Filter out empty strings
             urls = [url.strip() for url in data['notification_urls'] if url and url.strip()]
             creds['notification_urls'] = urls
-        
+
         # Validate Reddit credentials if requested or if they changed
         validate = data.get('validate', False)
         if validate:
@@ -488,9 +491,9 @@ def update_credentials():
                     'error': error,
                     'validation_failed': True
                 }), 400
-        
+
         save_credentials(creds)
-        
+
         return jsonify({
             'success': True,
             'configured': is_configured(),
@@ -546,22 +549,22 @@ def test_reddit_credentials():
     try:
         data = request.get_json()
         creds = load_credentials()
-        
+
         # Use provided values or fall back to stored ones (masked = untouched)
         client_id = resolve_credential(data, creds, 'reddit_client_id')
         client_secret = resolve_credential(data, creds, 'reddit_client_secret')
         username = resolve_credential(data, creds, 'reddit_username')
         password = resolve_credential(data, creds, 'reddit_password')
         user_agent = data.get('reddit_user_agent') or creds.get('reddit_user_agent', 'RedditMonitor/1.0')
-        
+
         if not all([client_id, client_secret, username, password]):
             return jsonify({
                 'success': False,
                 'error': 'Missing required Reddit credentials'
             }), 400
-        
+
         valid, error = validate_reddit_credentials(client_id, client_secret, username, password, user_agent)
-        
+
         return jsonify({
             'success': valid,
             'error': error
@@ -576,24 +579,24 @@ def test_notification():
     try:
         creds = load_credentials()
         notification_urls = creds.get('notification_urls', [])
-        
+
         if not notification_urls:
             return jsonify({
                 'success': False,
                 'error': 'No notification services configured'
             }), 400
-        
+
         # Create Apprise instance and add all URLs
         apobj = apprise.Apprise()
         for url in notification_urls:
             apobj.add(url)
-        
+
         # Send test notification
         result = apobj.notify(
             body="This is a test notification from Reddit Monitor. If you see this, notifications are working! 🎉",
             title="🧪 Test Notification"
         )
-        
+
         return jsonify({
             'success': result,
             'services_count': len(notification_urls),
@@ -605,11 +608,12 @@ def test_notification():
 
 
 if __name__ == '__main__':
-    print(f"📡 Reddit Monitor API starting...")
-    print(f"📁 Config file: {CONFIG_FILE_PATH}")
-    print(f"🔐 Credentials file: {CREDENTIALS_FILE_PATH}")
-    print(f"🌐 API available at: http://0.0.0.0:5001")
-    print(f"📱 Access from other devices using your local IP")
+    logging.basicConfig(level=logging.INFO, format='%(message)s')
+    logging.info("📡 Reddit Monitor API starting...")
+    logging.info(f"📁 Config file: {CONFIG_FILE_PATH}")
+    logging.info(f"🔐 Credentials file: {CREDENTIALS_FILE_PATH}")
+    logging.info("🌐 API available at: http://0.0.0.0:5001")
+    logging.info("📱 Access from other devices using your local IP")
     # Use debug=False in production for better performance
     debug_mode = os.environ.get('FLASK_DEBUG', 'false').lower() == 'true'
     app.run(host='0.0.0.0', port=5001, debug=debug_mode)

--- a/bot.py
+++ b/bot.py
@@ -56,6 +56,7 @@ def main():
     subreddits_to_search = cfg.get('subreddits_to_search', [])
     config.apply_source_order_from_config(cfg)
     last_config_mtime = config.get_config_mtime()
+    last_creds_mtime = config.get_credentials_mtime()
 
     # Track last run time for each monitor by ID
     last_run_times = {}
@@ -75,6 +76,15 @@ def main():
                 logging.info("Configuration reloaded successfully.")
             else:
                 logging.warning("Failed to reload configuration, using previous settings.")
+
+        # Reload credentials when credentials.json changes (e.g. a Sylvia key or Reddit
+        # app entered via the UI) so new keys take effect without restarting the bot.
+        current_creds_mtime = config.get_credentials_mtime()
+        if current_creds_mtime != last_creds_mtime:
+            logging.info("Credentials changed, reloading...")
+            credentials.detect_auth_capability()   # re-bridges the Sylvia key into sources
+            reddit = credentials.authenticate_reddit()  # pick up new/changed Reddit app creds
+            last_creds_mtime = current_creds_mtime
 
         # Filter to only enabled monitors
         enabled_monitors = [m for m in subreddits_to_search if m.get('enabled', True)]

--- a/bot.py
+++ b/bot.py
@@ -2,6 +2,7 @@
 
 Wiring + main loop only; the implementation lives in the reddit_scraper package.
 """
+
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -83,7 +84,7 @@ def main():
         current_creds_mtime = config.get_credentials_mtime()
         if current_creds_mtime != last_creds_mtime:
             logging.info("Credentials changed, reloading...")
-            credentials.detect_auth_capability()   # re-bridges the Sylvia key into sources
+            credentials.detect_auth_capability()  # re-bridges the Sylvia key into sources
             reddit = credentials.authenticate_reddit()  # pick up new/changed Reddit app creds
             last_creds_mtime = current_creds_mtime
 
@@ -105,11 +106,15 @@ def main():
             if time_since_last_run >= refresh_interval:
                 monitors_to_run.append(monitor)
                 last_run_times[monitor_id] = current_time
-                logging.info(f"Running monitor: {monitor.get('name', monitor.get('subreddit'))} "
-                             f"(interval: {monitor.get('cooldown_minutes', 10)} min)")
+                logging.info(
+                    f"Running monitor: {monitor.get('name', monitor.get('subreddit'))} "
+                    f"(interval: {monitor.get('cooldown_minutes', 10)} min)"
+                )
             else:
                 time_remaining = int((refresh_interval - time_since_last_run) / 60)
-                logging.debug(f"Skipping {monitor.get('name', monitor.get('subreddit'))} - {time_remaining} min until next run")
+                logging.debug(
+                    f"Skipping {monitor.get('name', monitor.get('subreddit'))} - {time_remaining} min until next run"
+                )
 
         if monitors_to_run:
             with ThreadPoolExecutor() as executor:

--- a/bot.py
+++ b/bot.py
@@ -2,15 +2,16 @@
 
 Wiring + main loop only; the implementation lives in the reddit_scraper package.
 """
-import time
 import logging
+import time
 from concurrent.futures import ThreadPoolExecutor
 
+from colorama import Fore, Style, init
 from dotenv import load_dotenv
-from colorama import init, Fore, Style
 
 from reddit_scraper import config, credentials, health
 from reddit_scraper.monitor import RedditMonitor
+
 # Re-exported for the test suite / external callers.
 from reddit_scraper.sources import fetch_posts_json, fetch_thread_comments_json  # noqa: F401
 

--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -30,6 +30,7 @@ const DEFAULT_CREDENTIALS: Credentials = {
 
 export default function SettingsModal({ onClose, onSave }: SettingsModalProps) {
     const [credentials, setCredentials] = useState<Credentials>(DEFAULT_CREDENTIALS);
+    const [dataSource, setDataSource] = useState<'reddit' | 'sylvia'>('reddit');
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
     const [testing, setTesting] = useState(false);
@@ -44,15 +45,20 @@ export default function SettingsModal({ onClose, onSave }: SettingsModalProps) {
 
     const fetchCredentials = async () => {
         try {
-            const response = await fetch(`${getApiUrl()}/api/credentials`);
-            const data = await response.json();
+            const [credRes, orderRes] = await Promise.all([
+                fetch(`${getApiUrl()}/api/credentials`),
+                fetch(`${getApiUrl()}/api/source-order`),
+            ]);
+            const data = await credRes.json();
             setCredentials({
                 ...DEFAULT_CREDENTIALS,
                 ...data,
                 notification_urls: data.notification_urls || [],
             });
+            const order = await orderRes.json();
+            if (order.active_source === 'sylvia') setDataSource('sylvia');
         } catch (err) {
-            console.error('Failed to fetch credentials:', err);
+            console.error('Failed to fetch settings:', err);
         } finally {
             setLoading(false);
         }
@@ -108,6 +114,13 @@ export default function SettingsModal({ onClose, onSave }: SettingsModalProps) {
         setSaving(true);
 
         try {
+            // Persist the selected data source (writes the bot's source order).
+            await fetch(`${getApiUrl()}/api/source-order`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ active_source: dataSource }),
+            });
+
             const response = await fetch(`${getApiUrl()}/api/credentials`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
@@ -164,7 +177,7 @@ export default function SettingsModal({ onClose, onSave }: SettingsModalProps) {
                                 ✕
                             </button>
                             <h2 className="text-xl font-semibold text-white">⚙️ Settings</h2>
-                            <p className="text-sm text-white/60 mt-1">Configure Reddit & notification services</p>
+                            <p className="text-sm text-white/60 mt-1">Choose your data source & notifications</p>
                         </div>
 
                         {loading ? (
@@ -173,83 +186,94 @@ export default function SettingsModal({ onClose, onSave }: SettingsModalProps) {
                             </div>
                         ) : (
                             <div className="p-4 space-y-6">
-                                {/* Reddit Section */}
+                                {/* Data Source Section */}
                                 <div>
                                     <h3 className="text-sm font-semibold text-white/80 mb-3 flex items-center gap-2">
-                                        🤖 Reddit API
+                                        📡 Data Source
                                     </h3>
                                     <div className="space-y-3">
                                         <div>
-                                            <label className="text-xs text-white/60 block mb-1">Client ID</label>
-                                            <input
-                                                type="text"
-                                                value={credentials.reddit_client_id}
-                                                onChange={(e) => handleChange('reddit_client_id', e.target.value)}
-                                                placeholder="Enter Client ID"
+                                            <label className="text-xs text-white/60 block mb-1">Fetch posts using</label>
+                                            <select
+                                                value={dataSource}
+                                                onChange={(e) => { setDataSource(e.target.value as 'reddit' | 'sylvia'); setError(null); setSuccess(false); }}
                                                 className="input-field text-sm"
-                                            />
+                                            >
+                                                <option value="reddit">🤖 Reddit API</option>
+                                                <option value="sylvia">🛰️ Sylvia Gateway</option>
+                                            </select>
+                                            <p className="text-xs text-white/40 mt-1">
+                                                {dataSource === 'reddit'
+                                                    ? 'Official Reddit API. Falls back to the free RSS/JSON feeds if unavailable.'
+                                                    : 'Third-party gateway that fetches from its own IP. Falls back to the free RSS/JSON feeds if unavailable.'}
+                                            </p>
                                         </div>
-                                        <div>
-                                            <label className="text-xs text-white/60 block mb-1">Client Secret</label>
-                                            <input
-                                                type="password"
-                                                value={credentials.reddit_client_secret}
-                                                onChange={(e) => handleChange('reddit_client_secret', e.target.value)}
-                                                placeholder="Enter Client Secret"
-                                                className="input-field text-sm"
-                                            />
-                                        </div>
-                                        <div>
-                                            <label className="text-xs text-white/60 block mb-1">Username</label>
-                                            <input
-                                                type="text"
-                                                value={credentials.reddit_username}
-                                                onChange={(e) => handleChange('reddit_username', e.target.value)}
-                                                placeholder="Your Reddit username"
-                                                className="input-field text-sm"
-                                            />
-                                        </div>
-                                        <div>
-                                            <label className="text-xs text-white/60 block mb-1">Password</label>
-                                            <input
-                                                type="password"
-                                                value={credentials.reddit_password}
-                                                onChange={(e) => handleChange('reddit_password', e.target.value)}
-                                                placeholder="Your Reddit password"
-                                                className="input-field text-sm"
-                                            />
-                                        </div>
-                                        <div>
-                                            <label className="text-xs text-white/60 block mb-1">User Agent</label>
-                                            <input
-                                                type="text"
-                                                value={credentials.reddit_user_agent}
-                                                onChange={(e) => handleChange('reddit_user_agent', e.target.value)}
-                                                placeholder="e.g. RedditMonitor by u/username"
-                                                className="input-field text-sm"
-                                            />
-                                        </div>
-                                    </div>
-                                </div>
 
-                                {/* Sylvia Gateway Section */}
-                                <div>
-                                    <h3 className="text-sm font-semibold text-white/80 mb-3 flex items-center gap-2">
-                                        🛰️ Sylvia Gateway <span className="text-xs text-white/40 font-normal">(optional fallback)</span>
-                                    </h3>
-                                    <div>
-                                        <label className="text-xs text-white/60 block mb-1">API Key</label>
-                                        <input
-                                            type="password"
-                                            value={credentials.sylvia_api_key}
-                                            onChange={(e) => handleChange('sylvia_api_key', e.target.value)}
-                                            placeholder="syl_..."
-                                            className="input-field text-sm"
-                                        />
-                                        <p className="text-xs text-white/40 mt-1">
-                                            Third-party Reddit gateway used as a fallback when the API is unavailable.
-                                            Add <code className="text-white/60">sylvia</code> to your source order to enable it.
-                                        </p>
+                                        {dataSource === 'reddit' ? (
+                                            <>
+                                                <div>
+                                                    <label className="text-xs text-white/60 block mb-1">Client ID</label>
+                                                    <input
+                                                        type="text"
+                                                        value={credentials.reddit_client_id}
+                                                        onChange={(e) => handleChange('reddit_client_id', e.target.value)}
+                                                        placeholder="Enter Client ID"
+                                                        className="input-field text-sm"
+                                                    />
+                                                </div>
+                                                <div>
+                                                    <label className="text-xs text-white/60 block mb-1">Client Secret</label>
+                                                    <input
+                                                        type="password"
+                                                        value={credentials.reddit_client_secret}
+                                                        onChange={(e) => handleChange('reddit_client_secret', e.target.value)}
+                                                        placeholder="Enter Client Secret"
+                                                        className="input-field text-sm"
+                                                    />
+                                                </div>
+                                                <div>
+                                                    <label className="text-xs text-white/60 block mb-1">Username</label>
+                                                    <input
+                                                        type="text"
+                                                        value={credentials.reddit_username}
+                                                        onChange={(e) => handleChange('reddit_username', e.target.value)}
+                                                        placeholder="Your Reddit username"
+                                                        className="input-field text-sm"
+                                                    />
+                                                </div>
+                                                <div>
+                                                    <label className="text-xs text-white/60 block mb-1">Password</label>
+                                                    <input
+                                                        type="password"
+                                                        value={credentials.reddit_password}
+                                                        onChange={(e) => handleChange('reddit_password', e.target.value)}
+                                                        placeholder="Your Reddit password"
+                                                        className="input-field text-sm"
+                                                    />
+                                                </div>
+                                                <div>
+                                                    <label className="text-xs text-white/60 block mb-1">User Agent</label>
+                                                    <input
+                                                        type="text"
+                                                        value={credentials.reddit_user_agent}
+                                                        onChange={(e) => handleChange('reddit_user_agent', e.target.value)}
+                                                        placeholder="e.g. RedditMonitor by u/username"
+                                                        className="input-field text-sm"
+                                                    />
+                                                </div>
+                                            </>
+                                        ) : (
+                                            <div>
+                                                <label className="text-xs text-white/60 block mb-1">API Key</label>
+                                                <input
+                                                    type="password"
+                                                    value={credentials.sylvia_api_key}
+                                                    onChange={(e) => handleChange('sylvia_api_key', e.target.value)}
+                                                    placeholder="syl_..."
+                                                    className="input-field text-sm"
+                                                />
+                                            </div>
+                                        )}
                                     </div>
                                 </div>
 

--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -2,35 +2,18 @@
 
 import { useState, useEffect } from 'react';
 import { getApiUrl } from '@/lib/api';
+import { Credentials, DEFAULT_CREDENTIALS, DataSource } from './settings/types';
+import DataSourceSection from './settings/DataSourceSection';
+import NotificationSection from './settings/NotificationSection';
 
 interface SettingsModalProps {
     onClose: () => void;
     onSave: () => void;
 }
 
-interface Credentials {
-    reddit_client_id: string;
-    reddit_client_secret: string;
-    reddit_username: string;
-    reddit_password: string;
-    reddit_user_agent: string;
-    sylvia_api_key: string;
-    notification_urls: string[];
-}
-
-const DEFAULT_CREDENTIALS: Credentials = {
-    reddit_client_id: '',
-    reddit_client_secret: '',
-    reddit_username: '',
-    reddit_password: '',
-    reddit_user_agent: '',
-    sylvia_api_key: '',
-    notification_urls: [],
-};
-
 export default function SettingsModal({ onClose, onSave }: SettingsModalProps) {
     const [credentials, setCredentials] = useState<Credentials>(DEFAULT_CREDENTIALS);
-    const [dataSource, setDataSource] = useState<'reddit' | 'sylvia'>('reddit');
+    const [dataSource, setDataSource] = useState<DataSource>('reddit');
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
     const [testing, setTesting] = useState(false);
@@ -145,19 +128,6 @@ export default function SettingsModal({ onClose, onSave }: SettingsModalProps) {
         }
     };
 
-    // Get service name from URL for display
-    const getServiceName = (url: string) => {
-        if (url.startsWith('discord://')) return '📱 Discord';
-        if (url.startsWith('slack://')) return '💬 Slack';
-        if (url.startsWith('tgram://')) return '✈️ Telegram';
-        if (url.startsWith('pover://')) return '📲 Pushover';
-        if (url.startsWith('ntfy://')) return '🔔 ntfy';
-        if (url.startsWith('mailto://')) return '📧 Email';
-        if (url.startsWith('msteams://')) return '👥 Teams';
-        if (url.includes('://')) return url.split('://')[0];
-        return 'Custom';
-    };
-
     return (
         <div className="modal-overlay animate-fade-in" onClick={onClose}>
             <div
@@ -186,184 +156,23 @@ export default function SettingsModal({ onClose, onSave }: SettingsModalProps) {
                             </div>
                         ) : (
                             <div className="p-4 space-y-6">
-                                {/* Data Source Section */}
-                                <div>
-                                    <h3 className="text-sm font-semibold text-white/80 mb-3 flex items-center gap-2">
-                                        📡 Data Source
-                                    </h3>
-                                    <div className="space-y-3">
-                                        <div>
-                                            <label className="text-xs text-white/60 block mb-1">Fetch posts using</label>
-                                            <select
-                                                value={dataSource}
-                                                onChange={(e) => { setDataSource(e.target.value as 'reddit' | 'sylvia'); setError(null); setSuccess(false); }}
-                                                className="input-field text-sm"
-                                            >
-                                                <option value="reddit">🤖 Reddit API</option>
-                                                <option value="sylvia">🛰️ Sylvia Gateway</option>
-                                            </select>
-                                            <p className="text-xs text-white/40 mt-1">
-                                                {dataSource === 'reddit'
-                                                    ? 'Official Reddit API. Falls back to the free RSS/JSON feeds if unavailable.'
-                                                    : 'Third-party gateway that fetches from its own IP. Falls back to the free RSS/JSON feeds if unavailable.'}
-                                            </p>
-                                        </div>
+                                <DataSourceSection
+                                    credentials={credentials}
+                                    dataSource={dataSource}
+                                    onDataSourceChange={(s) => { setDataSource(s); setError(null); setSuccess(false); }}
+                                    onChange={handleChange}
+                                />
 
-                                        {dataSource === 'reddit' ? (
-                                            <>
-                                                <div>
-                                                    <label className="text-xs text-white/60 block mb-1">Client ID</label>
-                                                    <input
-                                                        type="text"
-                                                        value={credentials.reddit_client_id}
-                                                        onChange={(e) => handleChange('reddit_client_id', e.target.value)}
-                                                        placeholder="Enter Client ID"
-                                                        className="input-field text-sm"
-                                                    />
-                                                </div>
-                                                <div>
-                                                    <label className="text-xs text-white/60 block mb-1">Client Secret</label>
-                                                    <input
-                                                        type="password"
-                                                        value={credentials.reddit_client_secret}
-                                                        onChange={(e) => handleChange('reddit_client_secret', e.target.value)}
-                                                        placeholder="Enter Client Secret"
-                                                        className="input-field text-sm"
-                                                    />
-                                                </div>
-                                                <div>
-                                                    <label className="text-xs text-white/60 block mb-1">Username</label>
-                                                    <input
-                                                        type="text"
-                                                        value={credentials.reddit_username}
-                                                        onChange={(e) => handleChange('reddit_username', e.target.value)}
-                                                        placeholder="Your Reddit username"
-                                                        className="input-field text-sm"
-                                                    />
-                                                </div>
-                                                <div>
-                                                    <label className="text-xs text-white/60 block mb-1">Password</label>
-                                                    <input
-                                                        type="password"
-                                                        value={credentials.reddit_password}
-                                                        onChange={(e) => handleChange('reddit_password', e.target.value)}
-                                                        placeholder="Your Reddit password"
-                                                        className="input-field text-sm"
-                                                    />
-                                                </div>
-                                                <div>
-                                                    <label className="text-xs text-white/60 block mb-1">User Agent</label>
-                                                    <input
-                                                        type="text"
-                                                        value={credentials.reddit_user_agent}
-                                                        onChange={(e) => handleChange('reddit_user_agent', e.target.value)}
-                                                        placeholder="e.g. RedditMonitor by u/username"
-                                                        className="input-field text-sm"
-                                                    />
-                                                </div>
-                                            </>
-                                        ) : (
-                                            <div>
-                                                <label className="text-xs text-white/60 block mb-1">API Key</label>
-                                                <input
-                                                    type="password"
-                                                    value={credentials.sylvia_api_key}
-                                                    onChange={(e) => handleChange('sylvia_api_key', e.target.value)}
-                                                    placeholder="syl_..."
-                                                    className="input-field text-sm"
-                                                />
-                                            </div>
-                                        )}
-                                    </div>
-                                </div>
-
-                                {/* Notification Services Section */}
-                                <div>
-                                    <h3 className="text-sm font-semibold text-white/80 mb-3 flex items-center gap-2">
-                                        🔔 Notification Services
-                                    </h3>
-
-                                    {/* Existing URLs */}
-                                    <div className="space-y-2 mb-3">
-                                        {credentials.notification_urls.map((url, index) => (
-                                            <div key={index} className="flex items-center gap-2 bg-white/5 rounded-lg p-2">
-                                                <span className="text-sm text-white flex-1 truncate">
-                                                    {getServiceName(url)}
-                                                </span>
-                                                <code className="text-xs text-white/40 flex-1 truncate">
-                                                    {url.length > 25 ? url.substring(0, 25) + '...' : url}
-                                                </code>
-                                                <button
-                                                    type="button"
-                                                    onClick={() => removeNotificationUrl(index)}
-                                                    className="text-red-400 hover:text-red-300 p-1"
-                                                >
-                                                    🗑️
-                                                </button>
-                                            </div>
-                                        ))}
-                                        {credentials.notification_urls.length === 0 && (
-                                            <p className="text-sm text-white/40 italic">No notification services configured</p>
-                                        )}
-                                    </div>
-
-                                    {/* Add new URL */}
-                                    <div className="flex gap-2 mb-3">
-                                        <input
-                                            type="text"
-                                            value={newUrl}
-                                            onChange={(e) => setNewUrl(e.target.value)}
-                                            onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), addNotificationUrl())}
-                                            placeholder="discord://webhook_id/token"
-                                            className="input-field text-sm flex-1"
-                                        />
-                                        <button
-                                            type="button"
-                                            onClick={addNotificationUrl}
-                                            className="px-3 py-2 bg-white/10 hover:bg-white/20 rounded-lg text-white"
-                                        >
-                                            +
-                                        </button>
-                                    </div>
-
-                                    {/* Test button */}
-                                    {credentials.notification_urls.length > 0 && (
-                                        <button
-                                            type="button"
-                                            onClick={testNotifications}
-                                            disabled={testing}
-                                            className="w-full py-2 bg-blue-500/20 hover:bg-blue-500/30 text-blue-300 rounded-lg text-sm transition-colors mb-3"
-                                        >
-                                            {testing ? '⏳ Testing...' : '🧪 Test Notifications'}
-                                        </button>
-                                    )}
-                                    {testSuccess === true && (
-                                        <p className="text-sm text-green-400">✅ Test notification sent!</p>
-                                    )}
-                                    {testSuccess === false && (
-                                        <p className="text-sm text-red-400">❌ Test failed</p>
-                                    )}
-
-                                    {/* Help text */}
-                                    <div className="bg-white/5 rounded-lg p-3 text-xs text-white/50">
-                                        <p className="font-semibold mb-1">Supported services:</p>
-                                        <ul className="space-y-0.5">
-                                            <li>• Discord: <code>discord://webhook_id/token</code></li>
-                                            <li>• Slack: <code>slack://token/channel</code></li>
-                                            <li>• Telegram: <code>tgram://bot_token/chat_id</code></li>
-                                            <li>• Pushover: <code>pover://user_key@app_token</code></li>
-                                            <li>• ntfy: <code>ntfy://topic</code></li>
-                                        </ul>
-                                        <a
-                                            href="https://github.com/caronc/apprise"
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            className="text-blue-400 hover:underline mt-2 block"
-                                        >
-                                            See all 80+ services →
-                                        </a>
-                                    </div>
-                                </div>
+                                <NotificationSection
+                                    urls={credentials.notification_urls}
+                                    newUrl={newUrl}
+                                    onNewUrlChange={setNewUrl}
+                                    onAdd={addNotificationUrl}
+                                    onRemove={removeNotificationUrl}
+                                    onTest={testNotifications}
+                                    testing={testing}
+                                    testSuccess={testSuccess}
+                                />
                             </div>
                         )}
                     </div>

--- a/frontend/components/settings/DataSourceSection.tsx
+++ b/frontend/components/settings/DataSourceSection.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import type { Credentials, DataSource } from './types';
+
+interface Props {
+    credentials: Credentials;
+    dataSource: DataSource;
+    onDataSourceChange: (source: DataSource) => void;
+    onChange: (field: keyof Credentials, value: string) => void;
+}
+
+export default function DataSourceSection({ credentials, dataSource, onDataSourceChange, onChange }: Props) {
+    return (
+        <div>
+            <h3 className="text-sm font-semibold text-white/80 mb-3 flex items-center gap-2">
+                📡 Data Source
+            </h3>
+            <div className="space-y-3">
+                <div>
+                    <label className="text-xs text-white/60 block mb-1">Fetch posts using</label>
+                    <select
+                        value={dataSource}
+                        onChange={(e) => onDataSourceChange(e.target.value as DataSource)}
+                        className="input-field text-sm"
+                    >
+                        <option value="reddit">🤖 Reddit API</option>
+                        <option value="sylvia">🛰️ Sylvia Gateway</option>
+                    </select>
+                    <p className="text-xs text-white/40 mt-1">
+                        {dataSource === 'reddit'
+                            ? 'Official Reddit API. Falls back to the free RSS/JSON feeds if unavailable.'
+                            : 'Third-party gateway that fetches from its own IP. Falls back to the free RSS/JSON feeds if unavailable.'}
+                    </p>
+                </div>
+
+                {dataSource === 'reddit' ? (
+                    <>
+                        <div>
+                            <label className="text-xs text-white/60 block mb-1">Client ID</label>
+                            <input
+                                type="text"
+                                value={credentials.reddit_client_id}
+                                onChange={(e) => onChange('reddit_client_id', e.target.value)}
+                                placeholder="Enter Client ID"
+                                className="input-field text-sm"
+                            />
+                        </div>
+                        <div>
+                            <label className="text-xs text-white/60 block mb-1">Client Secret</label>
+                            <input
+                                type="password"
+                                value={credentials.reddit_client_secret}
+                                onChange={(e) => onChange('reddit_client_secret', e.target.value)}
+                                placeholder="Enter Client Secret"
+                                className="input-field text-sm"
+                            />
+                        </div>
+                        <div>
+                            <label className="text-xs text-white/60 block mb-1">Username</label>
+                            <input
+                                type="text"
+                                value={credentials.reddit_username}
+                                onChange={(e) => onChange('reddit_username', e.target.value)}
+                                placeholder="Your Reddit username"
+                                className="input-field text-sm"
+                            />
+                        </div>
+                        <div>
+                            <label className="text-xs text-white/60 block mb-1">Password</label>
+                            <input
+                                type="password"
+                                value={credentials.reddit_password}
+                                onChange={(e) => onChange('reddit_password', e.target.value)}
+                                placeholder="Your Reddit password"
+                                className="input-field text-sm"
+                            />
+                        </div>
+                        <div>
+                            <label className="text-xs text-white/60 block mb-1">User Agent</label>
+                            <input
+                                type="text"
+                                value={credentials.reddit_user_agent}
+                                onChange={(e) => onChange('reddit_user_agent', e.target.value)}
+                                placeholder="e.g. RedditMonitor by u/username"
+                                className="input-field text-sm"
+                            />
+                        </div>
+                    </>
+                ) : (
+                    <div>
+                        <label className="text-xs text-white/60 block mb-1">API Key</label>
+                        <input
+                            type="password"
+                            value={credentials.sylvia_api_key}
+                            onChange={(e) => onChange('sylvia_api_key', e.target.value)}
+                            placeholder="syl_..."
+                            className="input-field text-sm"
+                        />
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/components/settings/NotificationSection.tsx
+++ b/frontend/components/settings/NotificationSection.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+interface Props {
+    urls: string[];
+    newUrl: string;
+    onNewUrlChange: (value: string) => void;
+    onAdd: () => void;
+    onRemove: (index: number) => void;
+    onTest: () => void;
+    testing: boolean;
+    testSuccess: boolean | null;
+}
+
+// Get a friendly service name from an Apprise URL for display.
+function getServiceName(url: string) {
+    if (url.startsWith('discord://')) return '📱 Discord';
+    if (url.startsWith('slack://')) return '💬 Slack';
+    if (url.startsWith('tgram://')) return '✈️ Telegram';
+    if (url.startsWith('pover://')) return '📲 Pushover';
+    if (url.startsWith('ntfy://')) return '🔔 ntfy';
+    if (url.startsWith('mailto://')) return '📧 Email';
+    if (url.startsWith('msteams://')) return '👥 Teams';
+    if (url.includes('://')) return url.split('://')[0];
+    return 'Custom';
+}
+
+export default function NotificationSection({
+    urls, newUrl, onNewUrlChange, onAdd, onRemove, onTest, testing, testSuccess,
+}: Props) {
+    return (
+        <div>
+            <h3 className="text-sm font-semibold text-white/80 mb-3 flex items-center gap-2">
+                🔔 Notification Services
+            </h3>
+
+            {/* Existing URLs */}
+            <div className="space-y-2 mb-3">
+                {urls.map((url, index) => (
+                    <div key={index} className="flex items-center gap-2 bg-white/5 rounded-lg p-2">
+                        <span className="text-sm text-white flex-1 truncate">
+                            {getServiceName(url)}
+                        </span>
+                        <code className="text-xs text-white/40 flex-1 truncate">
+                            {url.length > 25 ? url.substring(0, 25) + '...' : url}
+                        </code>
+                        <button
+                            type="button"
+                            onClick={() => onRemove(index)}
+                            className="text-red-400 hover:text-red-300 p-1"
+                        >
+                            🗑️
+                        </button>
+                    </div>
+                ))}
+                {urls.length === 0 && (
+                    <p className="text-sm text-white/40 italic">No notification services configured</p>
+                )}
+            </div>
+
+            {/* Add new URL */}
+            <div className="flex gap-2 mb-3">
+                <input
+                    type="text"
+                    value={newUrl}
+                    onChange={(e) => onNewUrlChange(e.target.value)}
+                    onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), onAdd())}
+                    placeholder="discord://webhook_id/token"
+                    className="input-field text-sm flex-1"
+                />
+                <button
+                    type="button"
+                    onClick={onAdd}
+                    className="px-3 py-2 bg-white/10 hover:bg-white/20 rounded-lg text-white"
+                >
+                    +
+                </button>
+            </div>
+
+            {/* Test button */}
+            {urls.length > 0 && (
+                <button
+                    type="button"
+                    onClick={onTest}
+                    disabled={testing}
+                    className="w-full py-2 bg-blue-500/20 hover:bg-blue-500/30 text-blue-300 rounded-lg text-sm transition-colors mb-3"
+                >
+                    {testing ? '⏳ Testing...' : '🧪 Test Notifications'}
+                </button>
+            )}
+            {testSuccess === true && (
+                <p className="text-sm text-green-400">✅ Test notification sent!</p>
+            )}
+            {testSuccess === false && (
+                <p className="text-sm text-red-400">❌ Test failed</p>
+            )}
+
+            {/* Help text */}
+            <div className="bg-white/5 rounded-lg p-3 text-xs text-white/50">
+                <p className="font-semibold mb-1">Supported services:</p>
+                <ul className="space-y-0.5">
+                    <li>• Discord: <code>discord://webhook_id/token</code></li>
+                    <li>• Slack: <code>slack://token/channel</code></li>
+                    <li>• Telegram: <code>tgram://bot_token/chat_id</code></li>
+                    <li>• Pushover: <code>pover://user_key@app_token</code></li>
+                    <li>• ntfy: <code>ntfy://topic</code></li>
+                </ul>
+                <a
+                    href="https://github.com/caronc/apprise"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-400 hover:underline mt-2 block"
+                >
+                    See all 80+ services →
+                </a>
+            </div>
+        </div>
+    );
+}

--- a/frontend/components/settings/types.ts
+++ b/frontend/components/settings/types.ts
@@ -1,0 +1,21 @@
+export interface Credentials {
+    reddit_client_id: string;
+    reddit_client_secret: string;
+    reddit_username: string;
+    reddit_password: string;
+    reddit_user_agent: string;
+    sylvia_api_key: string;
+    notification_urls: string[];
+}
+
+export const DEFAULT_CREDENTIALS: Credentials = {
+    reddit_client_id: '',
+    reddit_client_secret: '',
+    reddit_username: '',
+    reddit_password: '',
+    reddit_user_agent: '',
+    sylvia_api_key: '',
+    notification_urls: [],
+};
+
+export type DataSource = 'reddit' | 'sylvia';

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,8 @@ A self-hosted Reddit monitoring bot with a modern web UI. Get instant notificati
 - **🔔 80+ Notification Services** - Discord, Slack, Telegram, Pushover, ntfy, Email, and more via [Apprise](https://github.com/caronc/apprise)
 - **⏱️ Per-Monitor Refresh** - Each monitor can have its own check interval (1 min to 1 hour)
 - **🎯 Advanced Filters** - Keywords, exclusions, domain filters, flair filters, author filters
-- **🛟 Resilient Fetching** - Falls through multiple data sources (authenticated API → RSS → JSON) so it keeps working even when Reddit blocks anonymous access
+- **🛟 Resilient Fetching** - Falls through multiple data sources (authenticated API → optional Sylvia gateway → JSON → RSS) so it keeps working even when Reddit blocks anonymous access
+- **🕶️ IP Hiding** - Optionally route anonymous fetches through a proxy/pool, or use the Sylvia gateway, so requests aren't all made from one flagged IP
 - **🔓 Credentials Optional** - Runs on the public RSS feed with no Reddit app at all; add an app for full filtering and higher limits
 - **📟 Uptime Kuma Ready** - Optional push heartbeats report real health (not just "container running") and flag fallback degradation
 - **🐳 Docker Ready** - Easy deployment with Docker Compose
@@ -146,7 +147,7 @@ Each monitor supports these options:
 | `enabled` | Active/inactive toggle | `true` |
 | `color` | UI card color | Auto-assigned |
 
-> ⚠️ **Score and domain filters require the authenticated API.** The RSS pathway doesn't expose upvotes or the external domain, so `min_upvotes`, `domain_contains`, and `domain_excludes` are not applied while running on RSS (they fail safe — no false notifications). The web UI hides these fields when no Reddit app is configured.
+> ⚠️ **Score and domain filters require a full-data source** (the authenticated API or the Sylvia gateway). The RSS pathway doesn't expose upvotes or the external domain, so `min_upvotes`, `domain_contains`, and `domain_excludes` are not applied while running on RSS (they fail safe — no false notifications). The web UI hides these fields unless a source that provides them is configured.
 
 ### Example search.json
 
@@ -275,6 +276,7 @@ The bot fetches posts/comments through an ordered chain of sources, trying each 
 | Source | Auth | Notes |
 |--------|------|-------|
 | `oauth` | Reddit app | Authenticated API (full login **or** read-only app-only). Unblocked, 100 req/min, full post data. |
+| `sylvia` | API key | Third-party [Sylvia gateway](https://sylvia-api.com) that fetches from **its own IP** (so it doubles as IP hiding) and returns **full post data (score, domain, flair)**. Paid per request, so **opt-in**: skipped unless `SYLVIA_API_KEY` is set. |
 | `json` | None | `old.reddit.com/.../new.json`. Often blocked by Reddit now, but when it works it returns **full post data (score, domain, flair)** — so it's preferred over RSS. |
 | `rss` | None | `www.reddit.com/r/<sub>/new/.rss`. Works without credentials but is per-IP rate-limited (throttled) and has **no score/domain** (see filter note above). |
 
@@ -282,16 +284,18 @@ Duplicate/concurrent requests for the same subreddit (or thread) are **coalesced
 
 ### Configuring the order
 
-Default is `oauth → json → rss` (JSON before RSS because it returns richer data when available). Override per deployment via `search.json`:
+The simplest way is the web UI: **Settings → Data Source** lets you pick **Reddit API** or **Sylvia Gateway**, which writes the source order (with the free RSS/JSON feeds kept as a fallback behind your choice) and takes effect live — no restart.
+
+Default is `oauth → json → rss` (JSON before RSS because it returns richer data when available). To set it manually, override per deployment via `search.json`:
 
 ```json
 {
-    "source_order": ["oauth", "json", "rss"],
+    "source_order": ["oauth", "sylvia", "json", "rss"],
     "subreddits_to_search": [ ... ]
 }
 ```
 
-…or with the `REDDIT_SOURCE_ORDER=oauth,json,rss` environment variable (`search.json` takes precedence).
+…or with the `REDDIT_SOURCE_ORDER=oauth,json,rss` environment variable (`search.json` — and therefore the UI picker — takes precedence).
 
 ### Environment variables
 
@@ -303,6 +307,10 @@ Default is `oauth → json → rss` (JSON before RSS because it returns richer d
 | `SOURCE_COOLDOWN_MAX_SECONDS` | `3600` | Cap on the exponential backoff cooldown |
 | `FETCH_CACHE_TTL_SECONDS` | `90` | How long a fetched result is shared across duplicate monitors |
 | `RSS_USER_AGENT` | (browser UA) | Override the User-Agent used for RSS requests |
+| `SYLVIA_API_KEY` | — | API key for the `sylvia` source (also settable in the UI). Blank → source disabled |
+| `REDDIT_PROXY` | — | Route the anonymous RSS/JSON requests through a single proxy (IP hiding); blank → direct |
+| `REDDIT_PROXIES` | — | Comma-separated proxy pool, rotated per request (takes precedence over `REDDIT_PROXY`) |
+| `PROXY_COOLDOWN_SECONDS` | `120` | How long to skip a proxy after it fails to connect |
 | `KUMA_PUSH_URL` | — | Uptime Kuma Push URL for the primary health heartbeat |
 | `KUMA_FETCH_STALE_SECONDS` | `1500` | Seconds without a successful fetch before reporting DOWN |
 | `KUMA_FALLBACK_PUSH_URL` | — | Optional second Push URL that flags `oauth → fallback` degradation |

--- a/reddit_scraper/config.py
+++ b/reddit_scraper/config.py
@@ -3,18 +3,31 @@
 Paths are resolved from the DATA_DIR env var at call time (not captured at import)
 so tests can repoint DATA_DIR and reload entrypoints without stale paths.
 """
+
 import json
 import logging
 import os
 import uuid
 
 DEFAULT_COLORS = [
-    '#8B5CF6', '#3B82F6', '#22C55E', '#EF4444',
-    '#F97316', '#EC4899', '#06B6D4', '#EAB308',
+    '#8B5CF6',
+    '#3B82F6',
+    '#22C55E',
+    '#EF4444',
+    '#F97316',
+    '#EC4899',
+    '#06B6D4',
+    '#EAB308',
 ]
 
-OPTIONAL_LIST_FIELDS = ['exclude_keywords', 'domain_contains', 'domain_excludes',
-                        'flair_contains', 'author_includes', 'author_excludes']
+OPTIONAL_LIST_FIELDS = [
+    'exclude_keywords',
+    'domain_contains',
+    'domain_excludes',
+    'flair_contains',
+    'author_includes',
+    'author_excludes',
+]
 
 # Data-source pathways, tried in order by the dispatcher:
 #   'oauth'  - authenticated PRAW API (full login OR app-only read-only). Richest + unblocked.

--- a/reddit_scraper/config.py
+++ b/reddit_scraper/config.py
@@ -3,10 +3,10 @@
 Paths are resolved from the DATA_DIR env var at call time (not captured at import)
 so tests can repoint DATA_DIR and reload entrypoints without stale paths.
 """
-import os
 import json
-import uuid
 import logging
+import os
+import uuid
 
 DEFAULT_COLORS = [
     '#8B5CF6', '#3B82F6', '#22C55E', '#EF4444',

--- a/reddit_scraper/config.py
+++ b/reddit_scraper/config.py
@@ -74,6 +74,13 @@ def get_config_mtime():
         return None
 
 
+def get_credentials_mtime():
+    try:
+        return os.path.getmtime(get_credentials_path())
+    except OSError:
+        return None
+
+
 def save_config(config):
     with open(get_config_path(), 'w') as f:
         json.dump(config, f, indent=4)

--- a/reddit_scraper/credentials.py
+++ b/reddit_scraper/credentials.py
@@ -1,7 +1,7 @@
 """Credential loading, sanitization, encoding checks, and PRAW authentication."""
-import os
 import json
 import logging
+import os
 
 import praw
 

--- a/reddit_scraper/credentials.py
+++ b/reddit_scraper/credentials.py
@@ -65,13 +65,22 @@ def load_credentials():
     }
 
 
+def find_non_ascii(value):
+    """Return [(index, char), ...] for every non-ASCII character in value (empty if clean).
+
+    Reddit credentials are always ASCII, so any hit here is a red flag — typically a
+    lookalike character (e.g. a Cyrillic 'І' pasted for a Latin 'I') that would fail auth.
+    """
+    return [(i, c) for i, c in enumerate(value or '') if ord(c) > 127]
+
+
 def sanitize_credential(value, name):
     """Remove non-ASCII characters from credentials that cause latin-1 encoding errors."""
     if not value:
         return value
     sanitized = value.encode('ascii', 'ignore').decode('ascii')
     if value != sanitized:
-        positions = [i for i, c in enumerate(value) if ord(c) > 127]
+        positions = [i for i, _ in find_non_ascii(value)]
         logging.warning(f"⚠️ Removed non-ASCII characters from {name}: found Unicode at positions {positions}")
     return sanitized
 
@@ -88,8 +97,7 @@ def check_credential_encoding(creds):
     offenders = []
     for key in ('reddit_client_id', 'reddit_client_secret', 'reddit_user_agent',
                 'reddit_username', 'reddit_password'):
-        value = creds.get(key) or ''
-        bad = [i for i, c in enumerate(value) if ord(c) > 127]
+        bad = [i for i, _ in find_non_ascii(creds.get(key))]
         if bad:
             offenders.append(f"{key} (positions {bad})")
 

--- a/reddit_scraper/credentials.py
+++ b/reddit_scraper/credentials.py
@@ -1,4 +1,5 @@
 """Credential loading, sanitization, encoding checks, and PRAW authentication."""
+
 import json
 import logging
 import os
@@ -95,16 +96,16 @@ def check_credential_encoding(creds):
     """
     global CREDENTIAL_WARNING
     offenders = []
-    for key in ('reddit_client_id', 'reddit_client_secret', 'reddit_user_agent',
-                'reddit_username', 'reddit_password'):
+    for key in ('reddit_client_id', 'reddit_client_secret', 'reddit_user_agent', 'reddit_username', 'reddit_password'):
         bad = [i for i, _ in find_non_ascii(creds.get(key))]
         if bad:
             offenders.append(f"{key} (positions {bad})")
 
     if offenders:
         CREDENTIAL_WARNING = (
-            "Non-ASCII characters detected in: " + "; ".join(offenders) +
-            ". This usually means a credential was pasted with a lookalike character "
+            "Non-ASCII characters detected in: "
+            + "; ".join(offenders)
+            + ". This usually means a credential was pasted with a lookalike character "
             "(e.g. Cyrillic 'І' for Latin 'I') and will cause a 401 / fall back to RSS. "
             "Re-copy the affected credential from https://www.reddit.com/prefs/apps."
         )
@@ -129,6 +130,7 @@ def detect_auth_capability():
     # the sources -> notifications -> credentials import cycle). Env var still works on its
     # own; this lets the key be set via the UI/credentials file too.
     from . import sources
+
     sources.SYLVIA_API_KEY = CREDENTIALS.get('sylvia_api_key')
     if CREDENTIALS.get('sylvia_api_key'):
         logging.info("🛰️  Sylvia gateway key configured (source 'sylvia' available if in the order).")
@@ -172,15 +174,15 @@ def authenticate_reddit():
 
     if username and password:
         logging.info("Authenticating Reddit (full OAuth)...")
-        return praw.Reddit(client_id=client_id,
-                           client_secret=client_secret,
-                           user_agent=user_agent,
-                           username=username,
-                           password=password)
+        return praw.Reddit(
+            client_id=client_id,
+            client_secret=client_secret,
+            user_agent=user_agent,
+            username=username,
+            password=password,
+        )
 
     logging.info("Authenticating Reddit (read-only, app-only)...")
-    reddit = praw.Reddit(client_id=client_id,
-                         client_secret=client_secret,
-                         user_agent=user_agent)
+    reddit = praw.Reddit(client_id=client_id, client_secret=client_secret, user_agent=user_agent)
     reddit.read_only = True
     return reddit

--- a/reddit_scraper/health.py
+++ b/reddit_scraper/health.py
@@ -25,7 +25,7 @@ def send_kuma_heartbeat():
     if push_url:
         stale_after = int(os.getenv('KUMA_FETCH_STALE_SECONDS', '1500'))  # 25 min
         now = time.time()
-        last = sources._LAST_FETCH_SUCCESS_TS
+        last = sources.get_last_fetch_success_ts()
 
         if last is not None and (now - last) < stale_after:
             status, msg = 'up', f"ok (last good fetch {int(now - last)}s ago)"
@@ -58,7 +58,7 @@ def send_kuma_fallback_heartbeat():
     if not url:
         return
 
-    active = sources._active_source
+    active = sources.get_active_source()
     if not _oauth_expected():
         status, msg = 'up', f"using {active or 'rss/json'} (by configuration)"
     elif active == 'oauth':

--- a/reddit_scraper/health.py
+++ b/reddit_scraper/health.py
@@ -6,6 +6,7 @@ is busy failing. These push heartbeats report real health instead:
 - the optional fallback heartbeat reports DOWN when OAuth is expected but the bot
   is on an RSS/JSON fallback, so degradation is alerted while the primary stays UP.
 """
+
 import logging
 import os
 import time

--- a/reddit_scraper/health.py
+++ b/reddit_scraper/health.py
@@ -6,9 +6,9 @@ is busy failing. These push heartbeats report real health instead:
 - the optional fallback heartbeat reports DOWN when OAuth is expected but the bot
   is on an RSS/JSON fallback, so degradation is alerted while the primary stays UP.
 """
+import logging
 import os
 import time
-import logging
 
 import requests
 

--- a/reddit_scraper/monitor.py
+++ b/reddit_scraper/monitor.py
@@ -1,4 +1,5 @@
 """RedditMonitor: evaluates a subreddit (or BST thread) against keyword/filter rules."""
+
 import logging
 import os
 import pickle
@@ -15,9 +16,20 @@ class RedditMonitor:
     _thread_cache = {}  # subreddit+pattern -> {thread_id, cached_at}
     THREAD_CACHE_TTL = 3600  # refresh cached thread ID every hour
 
-    def __init__(self, reddit, subreddit, keywords, min_upvotes=None, exclude_keywords=None,
-                 domain_contains=None, domain_excludes=None, flair_contains=None,
-                 author_includes=None, author_excludes=None, **kwargs):
+    def __init__(
+        self,
+        reddit,
+        subreddit,
+        keywords,
+        min_upvotes=None,
+        exclude_keywords=None,
+        domain_contains=None,
+        domain_excludes=None,
+        flair_contains=None,
+        author_includes=None,
+        author_excludes=None,
+        **kwargs,
+    ):
         self.reddit = reddit
         self.subreddit = subreddit
         self.keywords = keywords
@@ -107,7 +119,7 @@ class RedditMonitor:
         # Otherwise scan recent posts via the configured source chain.
         if not thread_id:
             posts, _ = sources.fetch_posts(self.subreddit, 25, self.reddit)
-            for post in (posts or []):
+            for post in posts or []:
                 if pattern in (post['title'] or '').lower():
                     if post.get('id'):
                         thread_id = post['id']
@@ -196,7 +208,7 @@ class RedditMonitor:
                 permalink=post['permalink'],
                 domain=post['domain'],
                 flair=post['link_flair_text'] or '',
-                author=post['author']
+                author=post['author'],
             )
 
         logging.info(f"Finished searching '{self.subreddit}' subreddit (source: {source}).")
@@ -208,11 +220,13 @@ class RedditMonitor:
             logging.debug(f"Skipping duplicate post: {title}")
             return False
 
-        message = f"Match found in '{self.subreddit}' subreddit:\n" \
-                  f"Title: {title}\n" \
-                  f"URL: {url}\n" \
-                  f"Upvotes: {score}\n" \
-                  f"Permalink: https://www.reddit.com{permalink}\n"
+        message = (
+            f"Match found in '{self.subreddit}' subreddit:\n"
+            f"Title: {title}\n"
+            f"URL: {url}\n"
+            f"Upvotes: {score}\n"
+            f"Permalink: https://www.reddit.com{permalink}\n"
+        )
 
         # Check filters
         title_lower = title.lower()
@@ -234,9 +248,16 @@ class RedditMonitor:
         meets_author_includes = not self.author_includes or author_name in [a.lower() for a in self.author_includes]
         meets_author_excludes = author_name not in [a.lower() for a in self.author_excludes]
 
-        if (has_all_keywords and not has_excluded and meets_upvotes and
-                meets_domain_contains and meets_domain_excludes and
-                meets_flair and meets_author_includes and meets_author_excludes):
+        if (
+            has_all_keywords
+            and not has_excluded
+            and meets_upvotes
+            and meets_domain_contains
+            and meets_domain_excludes
+            and meets_flair
+            and meets_author_includes
+            and meets_author_excludes
+        ):
             logging.info(message)
             self.send_push_notification(message)
             logging.info('-' * 40)

--- a/reddit_scraper/monitor.py
+++ b/reddit_scraper/monitor.py
@@ -1,8 +1,8 @@
 """RedditMonitor: evaluates a subreddit (or BST thread) against keyword/filter rules."""
-import os
-import time
-import pickle
 import logging
+import os
+import pickle
+import time
 
 from . import config, credentials, notifications, sources
 

--- a/reddit_scraper/monitor.py
+++ b/reddit_scraper/monitor.py
@@ -104,7 +104,7 @@ class RedditMonitor:
             except Exception as e:
                 logging.warning(f"PRAW error finding sticky BST thread: {e}")
 
-        # Otherwise scan recent posts via the source chain (oauth -> rss -> json).
+        # Otherwise scan recent posts via the configured source chain.
         if not thread_id:
             posts, _ = sources.fetch_posts(self.subreddit, 25, self.reddit)
             for post in (posts or []):

--- a/reddit_scraper/notifications.py
+++ b/reddit_scraper/notifications.py
@@ -1,4 +1,5 @@
 """Apprise-based notification dispatch."""
+
 import logging
 
 import apprise

--- a/reddit_scraper/sources.py
+++ b/reddit_scraper/sources.py
@@ -4,18 +4,18 @@ Posts/comments are fetched through several pathways, tried in the configured ord
 (see config.get_source_order). A source that errors or returns nothing is put on a
 short cooldown so we don't keep hammering a blocked endpoint.
 """
+import html
+import logging
 import os
 import re
-import html
-import time
-import logging
 import threading
+import time
 import xml.etree.ElementTree as ET
 from urllib.parse import urlparse
 
 import requests
 
-from . import config, status, notifications
+from . import config, notifications, status
 
 ATOM_NS = {'a': 'http://www.w3.org/2005/Atom'}
 RSS_USER_AGENT = os.getenv(

--- a/reddit_scraper/sources.py
+++ b/reddit_scraper/sources.py
@@ -26,23 +26,10 @@ RSS_USER_AGENT = os.getenv(
 JSON_USER_AGENT = ('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
                    '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36')
 
-# Tracks the last time ANY Reddit fetch genuinely succeeded (used by the Kuma heartbeat).
-_LAST_FETCH_SUCCESS_TS = None
-# The data source currently serving data.
-_active_source = None
-# Whether we've already notified about an OAuth 401 (reset on the next oauth success).
-_auth_error_notified = False
-
-_source_cooldown_until = {}      # source name -> epoch time until which it is skipped
-_source_failures = {}            # source name -> consecutive failure count (for backoff)
-_source_state_lock = threading.Lock()
+# --- Tuning knobs (config; read from env once, overridable in tests) ---
 SOURCE_COOLDOWN_SECONDS = int(os.getenv('SOURCE_COOLDOWN_SECONDS', '300'))      # base cooldown
 SOURCE_COOLDOWN_MAX = int(os.getenv('SOURCE_COOLDOWN_MAX_SECONDS', '3600'))     # cap on backoff
-
-# RSS is aggressively per-IP rate-limited, so serialize requests with a minimum gap.
-_rss_throttle_lock = threading.Lock()
-_rss_last_request = [0.0]
-RSS_MIN_INTERVAL = float(os.getenv('RSS_MIN_INTERVAL_SECONDS', '4'))
+RSS_MIN_INTERVAL = float(os.getenv('RSS_MIN_INTERVAL_SECONDS', '4'))            # min gap between RSS reqs
 
 # Optional proxying so the anonymous RSS/JSON endpoints aren't all hit from one IP
 # (the IP Reddit ends up flagging). REDDIT_PROXIES is a comma-separated pool rotated
@@ -58,9 +45,6 @@ def _parse_proxies():
     return [single] if single else []
 
 _PROXIES = _parse_proxies()
-_proxy_index = [0]
-_proxy_cooldown_until = {}        # proxy url -> epoch time until which it is skipped
-_proxy_lock = threading.Lock()
 PROXY_COOLDOWN_SECONDS = int(os.getenv('PROXY_COOLDOWN_SECONDS', '120'))
 
 # Sylvia (api.sylvia-api.com) is a third-party Reddit gateway that returns native-Reddit-
@@ -71,116 +55,209 @@ PROXY_COOLDOWN_SECONDS = int(os.getenv('PROXY_COOLDOWN_SECONDS', '120'))
 SYLVIA_API_KEY = os.getenv('SYLVIA_API_KEY')
 SYLVIA_BASE_URL = os.getenv('SYLVIA_BASE_URL', 'https://api.sylvia-api.com/v1/reddit').rstrip('/')
 SYLVIA_TIMEOUT = float(os.getenv('SYLVIA_TIMEOUT_SECONDS', '15'))
-_sylvia_key_warned = False       # so the "no key" skip is logged only once
 
 # Short-lived response cache so concurrent monitors covering the same subreddit/thread
 # share a single network request instead of each issuing its own (which both wastes
 # requests and trips rate limits). TTL only needs to span one scheduling burst.
 FETCH_CACHE_TTL = float(os.getenv('FETCH_CACHE_TTL_SECONDS', '90'))
-_fetch_cache = {}                # key -> (timestamp, value)
-_fetch_cache_lock = threading.Lock()
-_fetch_key_locks = {}            # key -> Lock (so concurrent callers coalesce, not stampede)
 
 
+class _SourceState:
+    """Mutable runtime state behind the fetch dispatcher: the fetch-success heartbeat,
+    the active source, source cooldowns + exponential backoff, the coalescing cache,
+    proxy rotation, the RSS throttle clock, and one-time-notification flags.
+
+    A single module-level instance (`_state`) owns it; the module-level functions below
+    are a thin facade over it, so callers and tests don't reach into individual fields.
+    Tuning knobs (SOURCE_COOLDOWN_*, RSS_MIN_INTERVAL, FETCH_CACHE_TTL,
+    PROXY_COOLDOWN_SECONDS, _PROXIES, SYLVIA_API_KEY) stay module-level config, read here
+    by name so tests can still override them.
+    """
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        """Reset all runtime state to fresh (called at import and between tests)."""
+        self.last_fetch_success_ts = None   # last time ANY fetch succeeded (Kuma heartbeat)
+        self.active_source = None           # data source currently serving data
+        self.auth_error_notified = False    # OAuth-401 notified? (reset on next oauth success)
+
+        self.source_cooldown_until = {}     # source -> epoch until which it is skipped
+        self.source_failures = {}           # source -> consecutive failure count (for backoff)
+        self._lock = threading.Lock()
+
+        self.rss_last_request = 0.0         # RSS is per-IP rate-limited; serialize with a gap
+        self._rss_lock = threading.Lock()
+
+        self.proxy_index = 0                # round-robin cursor over _PROXIES
+        self.proxy_cooldown_until = {}      # proxy -> epoch until which it is skipped
+        self._proxy_lock = threading.Lock()
+
+        self.fetch_cache = {}               # coalesce key -> (timestamp, value)
+        self.key_locks = {}                 # coalesce key -> Lock (callers share, not stampede)
+        self._cache_lock = threading.Lock()
+
+        self.sylvia_key_warned = False      # so the "no Sylvia key" skip logs once
+
+    # --- fetch-success heartbeat / active source ---
+    def record_fetch_success(self):
+        self.last_fetch_success_ts = time.time()
+
+    def set_active_source(self, source):
+        """Record (and surface) the active source, only when it changes."""
+        if source != self.active_source:
+            self.active_source = source
+            logging.info(f"📡 Active Reddit data source: {source}")
+            status.save_bot_status(source != 'oauth', f"Active data source: {source}", active_source=source)
+
+    # --- one-time OAuth-failure notification guard ---
+    def claim_auth_error_notification(self):
+        """Atomically claim the right to send the one-time OAuth-failure notification.
+        Monitors run concurrently, so without this guard every thread hitting the same
+        401 fires its own. Returns True for exactly one caller until reset on oauth success."""
+        with self._lock:
+            if self.auth_error_notified:
+                return False
+            self.auth_error_notified = True
+            return True
+
+    def reset_auth_error_notification(self):
+        with self._lock:
+            self.auth_error_notified = False
+
+    # --- source cooldown + exponential backoff ---
+    def source_available(self, name):
+        if name == 'sylvia' and not SYLVIA_API_KEY:
+            with self._lock:
+                if not self.sylvia_key_warned:
+                    logging.warning("Source 'sylvia' is in the order but SYLVIA_API_KEY is unset; skipping it.")
+                    self.sylvia_key_warned = True
+            return False
+        with self._lock:
+            return time.time() >= self.source_cooldown_until.get(name, 0)
+
+    def mark_source_down(self, name, seconds=None):
+        """Cool down a failed source. With no explicit duration, back off exponentially on
+        consecutive failures (base, 2x, 4x, ... capped) so a dead source gets a real rest."""
+        with self._lock:
+            if seconds is None:
+                n = self.source_failures.get(name, 0) + 1
+                self.source_failures[name] = n
+                cooldown = min(SOURCE_COOLDOWN_SECONDS * (2 ** (n - 1)), SOURCE_COOLDOWN_MAX)
+            else:
+                cooldown = seconds
+            self.source_cooldown_until[name] = time.time() + cooldown
+        logging.warning(f"Pausing Reddit source '{name}' for {int(cooldown)}s after failure")
+
+    def note_source_success(self, name):
+        """Reset a source's backoff after it succeeds."""
+        with self._lock:
+            self.source_failures[name] = 0
+
+    # --- coalescing cache ---
+    def coalesce(self, key, producer):
+        """Return a cached fresh value for key, or produce + cache it. Concurrent callers
+        for the same key wait on a per-key lock and share the single result."""
+        now = time.time()
+        with self._cache_lock:
+            entry = self.fetch_cache.get(key)
+            if entry and now - entry[0] < FETCH_CACHE_TTL:
+                return entry[1]
+            key_lock = self.key_locks.setdefault(key, threading.Lock())
+
+        with key_lock:
+            # Re-check inside the per-key lock: another thread may have just produced it.
+            now = time.time()
+            with self._cache_lock:
+                entry = self.fetch_cache.get(key)
+                if entry and now - entry[0] < FETCH_CACHE_TTL:
+                    return entry[1]
+            value = producer()
+            with self._cache_lock:
+                self.fetch_cache[key] = (time.time(), value)
+            return value
+
+    # --- RSS throttle ---
+    def rss_throttle(self):
+        """Block until at least RSS_MIN_INTERVAL seconds have passed since the last RSS request."""
+        with self._rss_lock:
+            wait = RSS_MIN_INTERVAL - (time.time() - self.rss_last_request)
+            if wait > 0:
+                time.sleep(wait)
+            self.rss_last_request = time.time()
+
+    # --- proxy rotation ---
+    def next_proxy(self):
+        """Round-robin the next proxy that isn't cooling down, or None if all are (or none set)."""
+        if not _PROXIES:
+            return None
+        now = time.time()
+        with self._proxy_lock:
+            n = len(_PROXIES)
+            for _ in range(n):
+                i = self.proxy_index % n
+                self.proxy_index = (i + 1) % n
+                proxy = _PROXIES[i]
+                if self.proxy_cooldown_until.get(proxy, 0) <= now:
+                    return proxy
+            return None
+
+    def mark_proxy_down(self, proxy):
+        """Skip a proxy that failed to connect for a short while, then let it back in."""
+        with self._proxy_lock:
+            self.proxy_cooldown_until[proxy] = time.time() + PROXY_COOLDOWN_SECONDS
+
+
+_state = _SourceState()
+
+
+# --- thin module-level facade over _state (keeps existing call sites and tests stable) ---
 def record_fetch_success():
     """Mark that a Reddit fetch just succeeded (used by the Kuma heartbeat)."""
-    global _LAST_FETCH_SUCCESS_TS
-    _LAST_FETCH_SUCCESS_TS = time.time()
+    _state.record_fetch_success()
+
+
+def get_last_fetch_success_ts():
+    """Epoch of the last successful fetch, or None (used by the health heartbeat)."""
+    return _state.last_fetch_success_ts
+
+
+def get_active_source():
+    """The data source currently serving data, or None."""
+    return _state.active_source
 
 
 def _claim_auth_error_notification():
-    """Atomically claim the right to send the one-time OAuth-failure notification.
-
-    Monitors run concurrently, so without this guard every thread that hits the same
-    401 fires its own notification. Returns True for exactly one caller until reset
-    on the next oauth success.
-    """
-    global _auth_error_notified
-    with _source_state_lock:
-        if _auth_error_notified:
-            return False
-        _auth_error_notified = True
-        return True
+    return _state.claim_auth_error_notification()
 
 
 def _reset_auth_error_notification():
-    global _auth_error_notified
-    with _source_state_lock:
-        _auth_error_notified = False
+    _state.reset_auth_error_notification()
 
 
 def _source_available(name):
-    if name == 'sylvia' and not SYLVIA_API_KEY:
-        global _sylvia_key_warned
-        with _source_state_lock:
-            if not _sylvia_key_warned:
-                logging.warning("Source 'sylvia' is in the order but SYLVIA_API_KEY is unset; skipping it.")
-                _sylvia_key_warned = True
-        return False
-    with _source_state_lock:
-        return time.time() >= _source_cooldown_until.get(name, 0)
+    return _state.source_available(name)
 
 
 def _mark_source_down(name, seconds=None):
-    """Cool down a failed source. With no explicit duration, back off exponentially on
-    consecutive failures (base, 2x, 4x, ... capped) so a flagged IP / dead source gets
-    a real rest instead of being retried every cycle."""
-    with _source_state_lock:
-        if seconds is None:
-            n = _source_failures.get(name, 0) + 1
-            _source_failures[name] = n
-            cooldown = min(SOURCE_COOLDOWN_SECONDS * (2 ** (n - 1)), SOURCE_COOLDOWN_MAX)
-        else:
-            cooldown = seconds
-        _source_cooldown_until[name] = time.time() + cooldown
-    logging.warning(f"Pausing Reddit source '{name}' for {int(cooldown)}s after failure")
+    _state.mark_source_down(name, seconds)
 
 
 def _note_source_success(name):
-    """Reset a source's backoff after it succeeds."""
-    with _source_state_lock:
-        _source_failures[name] = 0
+    _state.note_source_success(name)
 
 
 def _coalesce(key, producer):
-    """Return a cached fresh value for key, or produce + cache it. Concurrent callers
-    for the same key wait on a per-key lock and share the single result."""
-    now = time.time()
-    with _fetch_cache_lock:
-        entry = _fetch_cache.get(key)
-        if entry and now - entry[0] < FETCH_CACHE_TTL:
-            return entry[1]
-        key_lock = _fetch_key_locks.setdefault(key, threading.Lock())
-
-    with key_lock:
-        # Re-check inside the per-key lock: another thread may have just produced it.
-        now = time.time()
-        with _fetch_cache_lock:
-            entry = _fetch_cache.get(key)
-            if entry and now - entry[0] < FETCH_CACHE_TTL:
-                return entry[1]
-        value = producer()
-        with _fetch_cache_lock:
-            _fetch_cache[key] = (time.time(), value)
-        return value
+    return _state.coalesce(key, producer)
 
 
 def _set_active_source(source):
-    """Record (and surface) the data source currently serving data, only when it changes."""
-    global _active_source
-    if source != _active_source:
-        _active_source = source
-        logging.info(f"📡 Active Reddit data source: {source}")
-        status.save_bot_status(source != 'oauth', f"Active data source: {source}", active_source=source)
+    _state.set_active_source(source)
 
 
 def _rss_throttle():
-    """Block until at least RSS_MIN_INTERVAL seconds have passed since the last RSS request."""
-    with _rss_throttle_lock:
-        wait = RSS_MIN_INTERVAL - (time.time() - _rss_last_request[0])
-        if wait > 0:
-            time.sleep(wait)
-        _rss_last_request[0] = time.time()
+    _state.rss_throttle()
 
 
 def _redact_proxy(proxy):
@@ -189,25 +266,11 @@ def _redact_proxy(proxy):
 
 
 def _next_proxy():
-    """Round-robin the next proxy that isn't cooling down, or None if all are (or none set)."""
-    if not _PROXIES:
-        return None
-    now = time.time()
-    with _proxy_lock:
-        n = len(_PROXIES)
-        for _ in range(n):
-            i = _proxy_index[0] % n
-            _proxy_index[0] = (i + 1) % n
-            proxy = _PROXIES[i]
-            if _proxy_cooldown_until.get(proxy, 0) <= now:
-                return proxy
-        return None
+    return _state.next_proxy()
 
 
 def _mark_proxy_down(proxy):
-    """Skip a proxy that failed to connect for a short while, then let it back in."""
-    with _proxy_lock:
-        _proxy_cooldown_until[proxy] = time.time() + PROXY_COOLDOWN_SECONDS
+    _state.mark_proxy_down(proxy)
 
 
 def _http_get(url, headers, timeout=15):

--- a/reddit_scraper/sources.py
+++ b/reddit_scraper/sources.py
@@ -4,6 +4,7 @@ Posts/comments are fetched through several pathways, tried in the configured ord
 (see config.get_source_order). A source that errors or returns nothing is put on a
 short cooldown so we don't keep hammering a blocked endpoint.
 """
+
 import html
 import logging
 import os
@@ -21,15 +22,17 @@ ATOM_NS = {'a': 'http://www.w3.org/2005/Atom'}
 RSS_USER_AGENT = os.getenv(
     'RSS_USER_AGENT',
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 '
-    '(KHTML, like Gecko) Version/17.0 Safari/605.1.15'
+    '(KHTML, like Gecko) Version/17.0 Safari/605.1.15',
 )
-JSON_USER_AGENT = ('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
-                   '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36')
+JSON_USER_AGENT = (
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+)
 
 # --- Tuning knobs (config; read from env once, overridable in tests) ---
-SOURCE_COOLDOWN_SECONDS = int(os.getenv('SOURCE_COOLDOWN_SECONDS', '300'))      # base cooldown
-SOURCE_COOLDOWN_MAX = int(os.getenv('SOURCE_COOLDOWN_MAX_SECONDS', '3600'))     # cap on backoff
-RSS_MIN_INTERVAL = float(os.getenv('RSS_MIN_INTERVAL_SECONDS', '4'))            # min gap between RSS reqs
+SOURCE_COOLDOWN_SECONDS = int(os.getenv('SOURCE_COOLDOWN_SECONDS', '300'))  # base cooldown
+SOURCE_COOLDOWN_MAX = int(os.getenv('SOURCE_COOLDOWN_MAX_SECONDS', '3600'))  # cap on backoff
+RSS_MIN_INTERVAL = float(os.getenv('RSS_MIN_INTERVAL_SECONDS', '4'))  # min gap between RSS reqs
+
 
 # Optional proxying so the anonymous RSS/JSON endpoints aren't all hit from one IP
 # (the IP Reddit ends up flagging). REDDIT_PROXIES is a comma-separated pool rotated
@@ -43,6 +46,7 @@ def _parse_proxies():
         return [p.strip() for p in pool.split(',') if p.strip()]
     single = (os.getenv('REDDIT_PROXY') or '').strip()
     return [single] if single else []
+
 
 _PROXIES = _parse_proxies()
 PROXY_COOLDOWN_SECONDS = int(os.getenv('PROXY_COOLDOWN_SECONDS', '120'))
@@ -79,26 +83,26 @@ class _SourceState:
 
     def reset(self):
         """Reset all runtime state to fresh (called at import and between tests)."""
-        self.last_fetch_success_ts = None   # last time ANY fetch succeeded (Kuma heartbeat)
-        self.active_source = None           # data source currently serving data
-        self.auth_error_notified = False    # OAuth-401 notified? (reset on next oauth success)
+        self.last_fetch_success_ts = None  # last time ANY fetch succeeded (Kuma heartbeat)
+        self.active_source = None  # data source currently serving data
+        self.auth_error_notified = False  # OAuth-401 notified? (reset on next oauth success)
 
-        self.source_cooldown_until = {}     # source -> epoch until which it is skipped
-        self.source_failures = {}           # source -> consecutive failure count (for backoff)
+        self.source_cooldown_until = {}  # source -> epoch until which it is skipped
+        self.source_failures = {}  # source -> consecutive failure count (for backoff)
         self._lock = threading.Lock()
 
-        self.rss_last_request = 0.0         # RSS is per-IP rate-limited; serialize with a gap
+        self.rss_last_request = 0.0  # RSS is per-IP rate-limited; serialize with a gap
         self._rss_lock = threading.Lock()
 
-        self.proxy_index = 0                # round-robin cursor over _PROXIES
-        self.proxy_cooldown_until = {}      # proxy -> epoch until which it is skipped
+        self.proxy_index = 0  # round-robin cursor over _PROXIES
+        self.proxy_cooldown_until = {}  # proxy -> epoch until which it is skipped
         self._proxy_lock = threading.Lock()
 
-        self.fetch_cache = {}               # coalesce key -> (timestamp, value)
-        self.key_locks = {}                 # coalesce key -> Lock (callers share, not stampede)
+        self.fetch_cache = {}  # coalesce key -> (timestamp, value)
+        self.key_locks = {}  # coalesce key -> Lock (callers share, not stampede)
         self._cache_lock = threading.Lock()
 
-        self.sylvia_key_warned = False      # so the "no Sylvia key" skip logs once
+        self.sylvia_key_warned = False  # so the "no Sylvia key" skip logs once
 
     # --- fetch-success heartbeat / active source ---
     def record_fetch_success(self):
@@ -290,11 +294,12 @@ def _http_get(url, headers, timeout=15):
         if proxy is None:
             break
         try:
-            return requests.get(url, headers=headers, timeout=timeout,
-                                 proxies={'http': proxy, 'https': proxy})
-        except (requests.exceptions.ProxyError,
-                requests.exceptions.ConnectTimeout,
-                requests.exceptions.ConnectionError) as e:
+            return requests.get(url, headers=headers, timeout=timeout, proxies={'http': proxy, 'https': proxy})
+        except (
+            requests.exceptions.ProxyError,
+            requests.exceptions.ConnectTimeout,
+            requests.exceptions.ConnectionError,
+        ) as e:
             last_err = e
             _mark_proxy_down(proxy)
             logging.warning(f"Proxy {_redact_proxy(proxy)} failed to connect: {e}; trying next")
@@ -311,16 +316,18 @@ def fetch_posts_json(subreddit, limit=10):
         posts = []
         for child in data.get('data', {}).get('children', []):
             post_data = child.get('data', {})
-            posts.append({
-                'id': post_data.get('id', ''),
-                'title': post_data.get('title', ''),
-                'url': post_data.get('url', ''),
-                'score': post_data.get('score', 0),
-                'permalink': post_data.get('permalink', ''),
-                'domain': post_data.get('domain', ''),
-                'link_flair_text': post_data.get('link_flair_text', ''),
-                'author': post_data.get('author', ''),
-            })
+            posts.append(
+                {
+                    'id': post_data.get('id', ''),
+                    'title': post_data.get('title', ''),
+                    'url': post_data.get('url', ''),
+                    'score': post_data.get('score', 0),
+                    'permalink': post_data.get('permalink', ''),
+                    'domain': post_data.get('domain', ''),
+                    'link_flair_text': post_data.get('link_flair_text', ''),
+                    'author': post_data.get('author', ''),
+                }
+            )
         record_fetch_success()
         return posts
     except requests.exceptions.RequestException as e:
@@ -345,13 +352,15 @@ def fetch_thread_comments_json(subreddit, thread_id, limit=500):
             if child.get('kind') != 't1':
                 continue
             d = child['data']
-            comments.append({
-                'id': d.get('id', ''),
-                'body': d.get('body', ''),
-                'author': d.get('author', ''),
-                'score': d.get('score', 0),
-                'permalink': d.get('permalink', ''),
-            })
+            comments.append(
+                {
+                    'id': d.get('id', ''),
+                    'body': d.get('body', ''),
+                    'author': d.get('author', ''),
+                    'score': d.get('score', 0),
+                    'permalink': d.get('permalink', ''),
+                }
+            )
         return comments
     except Exception as e:
         logging.error(f"Error fetching comments for thread {thread_id}: {e}")
@@ -362,8 +371,7 @@ def _sylvia_get(path):
     """GET a Sylvia gateway path with the API key. Raises RuntimeError on auth (401/403)
     and rate-limit (429) so the dispatcher cools the source down; raises for other HTTP
     errors too. Returns the parsed JSON body."""
-    response = requests.get(f"{SYLVIA_BASE_URL}{path}",
-                            headers={'X-API-KEY': SYLVIA_API_KEY}, timeout=SYLVIA_TIMEOUT)
+    response = requests.get(f"{SYLVIA_BASE_URL}{path}", headers={'X-API-KEY': SYLVIA_API_KEY}, timeout=SYLVIA_TIMEOUT)
     if response.status_code in (401, 403):
         raise RuntimeError(f"Sylvia auth failed ({response.status_code}); check SYLVIA_API_KEY")
     if response.status_code == 429:
@@ -379,16 +387,18 @@ def fetch_posts_sylvia(subreddit, limit=10):
     data = _sylvia_get(f"/r/{subreddit}/new?limit={limit}")
     posts = []
     for post_data in data.get('data', {}).get('posts', [])[:limit]:
-        posts.append({
-            'id': post_data.get('id', ''),
-            'title': post_data.get('title', ''),
-            'url': post_data.get('url', ''),
-            'score': post_data.get('score', 0),
-            'permalink': post_data.get('permalink', ''),
-            'domain': post_data.get('domain', ''),
-            'link_flair_text': post_data.get('link_flair_text') or '',
-            'author': post_data.get('author', ''),
-        })
+        posts.append(
+            {
+                'id': post_data.get('id', ''),
+                'title': post_data.get('title', ''),
+                'url': post_data.get('url', ''),
+                'score': post_data.get('score', 0),
+                'permalink': post_data.get('permalink', ''),
+                'domain': post_data.get('domain', ''),
+                'link_flair_text': post_data.get('link_flair_text') or '',
+                'author': post_data.get('author', ''),
+            }
+        )
     record_fetch_success()
     return posts
 
@@ -408,13 +418,15 @@ def fetch_thread_comments_sylvia(subreddit, thread_id, limit=500):
         if child.get('kind') != 't1':
             continue
         d = child['data']
-        comments.append({
-            'id': d.get('id', ''),
-            'body': d.get('body', ''),
-            'author': d.get('author', ''),
-            'score': d.get('score', 0),
-            'permalink': d.get('permalink', ''),
-        })
+        comments.append(
+            {
+                'id': d.get('id', ''),
+                'body': d.get('body', ''),
+                'author': d.get('author', ''),
+                'score': d.get('score', 0),
+                'permalink': d.get('permalink', ''),
+            }
+        )
     return comments
 
 
@@ -432,11 +444,12 @@ def fetch_posts_rss(subreddit, limit=10):
     root = ET.fromstring(response.content)
     posts = []
     for entry in root.findall('a:entry', ATOM_NS)[:limit]:
+
         def text(tag):
             el = entry.find(f'a:{tag}', ATOM_NS)
             return el.text if (el is not None and el.text) else ''
 
-        raw_id = text('id')                       # e.g. "t3_abc123"
+        raw_id = text('id')  # e.g. "t3_abc123"
         post_id = raw_id.split('_')[-1] if raw_id else ''
         link_el = entry.find('a:link', ATOM_NS)
         href = link_el.get('href') if link_el is not None else ''
@@ -448,16 +461,18 @@ def fetch_posts_rss(subreddit, limit=10):
         cat_el = entry.find('a:category', ATOM_NS)
         flair = cat_el.get('term') if cat_el is not None else ''
 
-        posts.append({
-            'id': post_id,
-            'title': text('title'),
-            'url': href,
-            'score': 0,            # not exposed via RSS
-            'permalink': permalink,
-            'domain': '',          # not exposed via RSS
-            'link_flair_text': flair or '',
-            'author': author,
-        })
+        posts.append(
+            {
+                'id': post_id,
+                'title': text('title'),
+                'url': href,
+                'score': 0,  # not exposed via RSS
+                'permalink': permalink,
+                'domain': '',  # not exposed via RSS
+                'link_flair_text': flair or '',
+                'author': author,
+            }
+        )
     return posts
 
 
@@ -475,7 +490,7 @@ def fetch_thread_comments_rss(subreddit, thread_id, limit=500):
     for entry in root.findall('a:entry', ATOM_NS):
         id_el = entry.find('a:id', ATOM_NS)
         raw_id = (id_el.text or '') if id_el is not None else ''
-        if not raw_id.startswith('t1_'):          # keep comments only, not the post itself
+        if not raw_id.startswith('t1_'):  # keep comments only, not the post itself
             continue
         content_el = entry.find('a:content', ATOM_NS)
         body_html = (content_el.text or '') if content_el is not None else ''
@@ -486,13 +501,15 @@ def fetch_thread_comments_rss(subreddit, thread_id, limit=500):
             author = author[3:]
         link_el = entry.find('a:link', ATOM_NS)
         permalink = urlparse(link_el.get('href')).path if link_el is not None else ''
-        comments.append({
-            'id': raw_id.split('_')[-1],
-            'body': body,
-            'author': author,
-            'score': 0,
-            'permalink': permalink,
-        })
+        comments.append(
+            {
+                'id': raw_id.split('_')[-1],
+                'body': body,
+                'author': author,
+                'score': 0,
+                'permalink': permalink,
+            }
+        )
     return comments
 
 
@@ -501,24 +518,25 @@ def _fetch_posts_oauth(reddit, subreddit, limit):
     sub = reddit.subreddit(subreddit)
     posts = []
     for s in sub.new(limit=limit):
-        posts.append({
-            'id': s.id,
-            'title': s.title,
-            'url': s.url,
-            'score': s.score,
-            'permalink': s.permalink,
-            'domain': getattr(s, 'domain', '') or '',
-            'link_flair_text': getattr(s, 'link_flair_text', '') or '',
-            'author': s.author.name if s.author else '',
-        })
+        posts.append(
+            {
+                'id': s.id,
+                'title': s.title,
+                'url': s.url,
+                'score': s.score,
+                'permalink': s.permalink,
+                'domain': getattr(s, 'domain', '') or '',
+                'link_flair_text': getattr(s, 'link_flair_text', '') or '',
+                'author': s.author.name if s.author else '',
+            }
+        )
     return posts
 
 
 def fetch_posts(subreddit, limit, reddit):
     """Fetch posts, coalescing concurrent/duplicate calls for the same subreddit+limit
     so overlapping monitors share one request. See _fetch_posts_impl for the chain."""
-    return _coalesce(('posts', subreddit, limit),
-                     lambda: _fetch_posts_impl(subreddit, limit, reddit))
+    return _coalesce(('posts', subreddit, limit), lambda: _fetch_posts_impl(subreddit, limit, reddit))
 
 
 def _fetch_posts_impl(subreddit, limit, reddit):
@@ -547,7 +565,8 @@ def _fetch_posts_impl(subreddit, limit, reddit):
             if source == 'oauth' and ('401' in error_str or 'unauthorized' in error_str.lower()):
                 if _claim_auth_error_notification():
                     notifications.notify_error(
-                        "Reddit API authentication failed (401). Falling back to alternative sources (RSS/JSON).")
+                        "Reddit API authentication failed (401). Falling back to alternative sources (RSS/JSON)."
+                    )
             logging.warning(f"Reddit source '{source}' failed for r/{subreddit}: {e}")
             _mark_source_down(source)
             continue
@@ -571,8 +590,9 @@ def _fetch_posts_impl(subreddit, limit, reddit):
 def fetch_thread_comments(subreddit, thread_id, reddit):
     """Fetch a thread's comments, coalescing concurrent/duplicate calls for the same
     thread so overlapping monitors share one request. See _fetch_thread_comments_impl."""
-    return _coalesce(('comments', subreddit, thread_id),
-                     lambda: _fetch_thread_comments_impl(subreddit, thread_id, reddit))
+    return _coalesce(
+        ('comments', subreddit, thread_id), lambda: _fetch_thread_comments_impl(subreddit, thread_id, reddit)
+    )
 
 
 def _fetch_thread_comments_impl(subreddit, thread_id, reddit):

--- a/reddit_scraper/sources.py
+++ b/reddit_scraper/sources.py
@@ -513,7 +513,7 @@ def fetch_thread_comments(subreddit, thread_id, reddit):
 
 
 def _fetch_thread_comments_impl(subreddit, thread_id, reddit):
-    """Fetch a thread's comments through the configured source chain (oauth -> rss -> json)."""
+    """Fetch a thread's comments through the configured source chain (see config.get_source_order)."""
     for source in config.get_source_order():
         if not _source_available(source):
             continue

--- a/reddit_scraper/status.py
+++ b/reddit_scraper/status.py
@@ -1,4 +1,5 @@
 """Bot status file written for the API/frontend to read."""
+
 import json
 import logging
 from datetime import datetime, timezone

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@
 pytest>=8.0.0
 pytest-mock>=3.12.0
 responses>=0.25.0
+ruff>=0.16.0  # lint + format; config in ruff.toml (see CLAUDE.md)

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,22 @@
+# Ruff config — the single source of truth for Python style/lint in this repo.
+# See CLAUDE.md ("Coding principles") for the conventions this enforces.
+line-length = 120
+target-version = "py39"
+extend-exclude = ["frontend", "**/__pycache__"]
+
+[lint]
+# E/W: pycodestyle, F: pyflakes (unused imports/vars, f-strings w/o placeholders),
+# I: import sorting. Deliberately conservative — no opinionated reformatting rules.
+select = ["E", "W", "F", "I"]
+# Line length is owned by the formatter; a handful of URLs/strings can't wrap, so
+# don't fail lint on length.
+ignore = ["E501"]
+
+[lint.per-file-ignores]
+# conftest must insert the repo root onto sys.path before importing project modules.
+"tests/conftest.py" = ["E402"]
+
+[format]
+# The codebase is intentionally mixed (single-quoted keys/literals, double-quoted
+# f-strings/messages); preserve that rather than churn every string.
+quote-style = "preserve"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 """Pytest configuration and fixtures for Reddit Monitor tests."""
-import sys
-import os
-import tempfile
 import json
+import os
+import sys
+import tempfile
 
 # Create temp data dir and credentials BEFORE any imports of bot.py
 _temp_dir = tempfile.mkdtemp()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Pytest configuration and fixtures for Reddit Monitor tests."""
+
 import json
 import os
 import sys
@@ -88,7 +89,7 @@ def mock_json_response():
                         'link_flair_text': 'BUYING',
                         'author': 'buyer456',
                     }
-                }
+                },
             ]
         }
     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -152,7 +152,32 @@ class TestCredentialsAPI:
         response = client.get('/api/credentials')
         assert response.status_code == 200
         data = response.get_json()
-        
+
         # Client ID should be partially masked
         if data.get('reddit_client_id'):
             assert '••••' in data['reddit_client_id']
+
+    def test_source_order_defaults_to_reddit(self, client):
+        """With no source_order saved, the active source reports as reddit."""
+        response = client.get('/api/source-order')
+        assert response.status_code == 200
+        assert response.get_json()['active_source'] == 'reddit'
+
+    def test_set_source_to_sylvia_persists(self, client):
+        """Selecting sylvia writes a sylvia-first order and reads back as sylvia."""
+        put = client.put('/api/source-order', json={'active_source': 'sylvia'})
+        assert put.status_code == 200
+        assert put.get_json()['source_order'] == ['sylvia', 'json', 'rss']
+        # persisted + reflected on the next GET
+        assert client.get('/api/source-order').get_json()['active_source'] == 'sylvia'
+
+    def test_set_source_back_to_reddit(self, client):
+        """Selecting reddit writes an oauth-first order."""
+        client.put('/api/source-order', json={'active_source': 'sylvia'})
+        put = client.put('/api/source-order', json={'active_source': 'reddit'})
+        assert put.get_json()['source_order'] == ['oauth', 'json', 'rss']
+
+    def test_invalid_source_rejected(self, client):
+        """An unknown source is rejected with 400."""
+        response = client.put('/api/source-order', json={'active_source': 'nope'})
+        assert response.status_code == 400

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -181,3 +181,12 @@ class TestCredentialsAPI:
         """An unknown source is rejected with 400."""
         response = client.put('/api/source-order', json={'active_source': 'nope'})
         assert response.status_code == 400
+
+    def test_sylvia_enables_rich_filters(self, client):
+        """On Sylvia (with a key), score/domain filters are reported as supported,
+        even without a Reddit app — Sylvia returns full post data."""
+        client.put('/api/source-order', json={'active_source': 'sylvia'})
+        client.put('/api/credentials', json={'sylvia_api_key': 'syl_test'})
+        status = client.get('/api/status').get_json()
+        assert status['rich_filters_supported'] is True
+        assert status['oauth_available'] is False  # no Reddit app configured

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,14 +1,15 @@
 """Unit tests for api.py functionality."""
-import pytest
 import json
 import os
 import tempfile
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
+
+import pytest
 
 
 class TestAPIEndpoints:
     """Tests for Flask API endpoints."""
-    
+
     @pytest.fixture
     def client(self):
         """Create Flask test client."""
@@ -18,21 +19,22 @@ class TestAPIEndpoints:
                 # Create empty config files
                 config_path = os.path.join(tmpdir, 'search.json')
                 creds_path = os.path.join(tmpdir, 'credentials.json')
-                
+
                 with open(config_path, 'w') as f:
                     json.dump({'subreddits_to_search': [], 'iteration_time_minutes': 5}, f)
                 with open(creds_path, 'w') as f:
                     json.dump({}, f)
-                
+
                 # Import after patching
                 import importlib
+
                 import api
                 importlib.reload(api)
-                
+
                 api.app.config['TESTING'] = True
                 with api.app.test_client() as client:
                     yield client
-    
+
     def test_get_monitors_empty(self, client):
         """Test getting monitors when none exist."""
         response = client.get('/api/monitors')
@@ -40,7 +42,7 @@ class TestAPIEndpoints:
         data = response.get_json()
         assert 'monitors' in data
         assert len(data['monitors']) == 0
-    
+
     def test_create_monitor(self, client):
         """Test creating a new monitor."""
         monitor_data = {
@@ -49,17 +51,17 @@ class TestAPIEndpoints:
             'name': 'GPU Hunt',
             'enabled': True,
         }
-        
-        response = client.post('/api/monitors', 
+
+        response = client.post('/api/monitors',
                                data=json.dumps(monitor_data),
                                content_type='application/json')
-        
+
         assert response.status_code == 201
         data = response.get_json()
         assert 'id' in data
         assert data['subreddit'] == 'hardwareswap'
         assert data['name'] == 'GPU Hunt'
-    
+
     def test_update_monitor(self, client):
         """Test updating an existing monitor."""
         # First create a monitor
@@ -72,7 +74,7 @@ class TestAPIEndpoints:
                                       data=json.dumps(monitor_data),
                                       content_type='application/json')
         monitor_id = create_response.get_json()['id']
-        
+
         # Update it
         update_data = {
             'name': 'GPU Hunt Updated',
@@ -81,12 +83,12 @@ class TestAPIEndpoints:
         response = client.put(f'/api/monitors/{monitor_id}',
                               data=json.dumps(update_data),
                               content_type='application/json')
-        
+
         assert response.status_code == 200
         data = response.get_json()
         assert data['name'] == 'GPU Hunt Updated'
         assert '3090' in data['keywords']
-    
+
     def test_delete_monitor(self, client):
         """Test deleting a monitor."""
         # First create a monitor
@@ -98,15 +100,15 @@ class TestAPIEndpoints:
                                       data=json.dumps(monitor_data),
                                       content_type='application/json')
         monitor_id = create_response.get_json()['id']
-        
+
         # Delete it
         response = client.delete(f'/api/monitors/{monitor_id}')
         assert response.status_code == 200
-        
+
         # Verify it's gone
         get_response = client.get('/api/monitors')
         assert len(get_response.get_json()['monitors']) == 0
-    
+
     def test_get_monitor_not_found(self, client):
         """Test getting a non-existent monitor."""
         response = client.get('/api/monitors/nonexistent-id')
@@ -115,7 +117,7 @@ class TestAPIEndpoints:
 
 class TestCredentialsAPI:
     """Tests for credentials API endpoints."""
-    
+
     @pytest.fixture
     def client(self):
         """Create Flask test client."""
@@ -123,7 +125,7 @@ class TestCredentialsAPI:
             with patch.dict(os.environ, {'DATA_DIR': tmpdir}):
                 config_path = os.path.join(tmpdir, 'search.json')
                 creds_path = os.path.join(tmpdir, 'credentials.json')
-                
+
                 with open(config_path, 'w') as f:
                     json.dump({'subreddits_to_search': []}, f)
                 with open(creds_path, 'w') as f:
@@ -131,22 +133,23 @@ class TestCredentialsAPI:
                         'reddit_client_id': 'testid123',
                         'reddit_client_secret': 'testsecret456',
                     }, f)
-                
+
                 import importlib
+
                 import api
                 importlib.reload(api)
-                
+
                 api.app.config['TESTING'] = True
                 with api.app.test_client() as client:
                     yield client
-    
+
     def test_credentials_status(self, client):
         """Test checking if credentials are configured."""
         response = client.get('/api/credentials/status')
         assert response.status_code == 200
         data = response.get_json()
         assert 'configured' in data
-    
+
     def test_get_credentials_masked(self, client):
         """Test that credentials are masked in response."""
         response = client.get('/api/credentials')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 """Unit tests for api.py functionality."""
+
 import json
 import os
 import tempfile
@@ -29,6 +30,7 @@ class TestAPIEndpoints:
                 import importlib
 
                 import api
+
                 importlib.reload(api)
 
                 api.app.config['TESTING'] = True
@@ -52,9 +54,7 @@ class TestAPIEndpoints:
             'enabled': True,
         }
 
-        response = client.post('/api/monitors',
-                               data=json.dumps(monitor_data),
-                               content_type='application/json')
+        response = client.post('/api/monitors', data=json.dumps(monitor_data), content_type='application/json')
 
         assert response.status_code == 201
         data = response.get_json()
@@ -70,9 +70,7 @@ class TestAPIEndpoints:
             'keywords': ['4090'],
             'name': 'GPU Hunt',
         }
-        create_response = client.post('/api/monitors',
-                                      data=json.dumps(monitor_data),
-                                      content_type='application/json')
+        create_response = client.post('/api/monitors', data=json.dumps(monitor_data), content_type='application/json')
         monitor_id = create_response.get_json()['id']
 
         # Update it
@@ -80,9 +78,9 @@ class TestAPIEndpoints:
             'name': 'GPU Hunt Updated',
             'keywords': ['4090', '4080', '3090'],
         }
-        response = client.put(f'/api/monitors/{monitor_id}',
-                              data=json.dumps(update_data),
-                              content_type='application/json')
+        response = client.put(
+            f'/api/monitors/{monitor_id}', data=json.dumps(update_data), content_type='application/json'
+        )
 
         assert response.status_code == 200
         data = response.get_json()
@@ -96,9 +94,7 @@ class TestAPIEndpoints:
             'subreddit': 'hardwareswap',
             'keywords': ['4090'],
         }
-        create_response = client.post('/api/monitors',
-                                      data=json.dumps(monitor_data),
-                                      content_type='application/json')
+        create_response = client.post('/api/monitors', data=json.dumps(monitor_data), content_type='application/json')
         monitor_id = create_response.get_json()['id']
 
         # Delete it
@@ -129,14 +125,18 @@ class TestCredentialsAPI:
                 with open(config_path, 'w') as f:
                     json.dump({'subreddits_to_search': []}, f)
                 with open(creds_path, 'w') as f:
-                    json.dump({
-                        'reddit_client_id': 'testid123',
-                        'reddit_client_secret': 'testsecret456',
-                    }, f)
+                    json.dump(
+                        {
+                            'reddit_client_id': 'testid123',
+                            'reddit_client_secret': 'testsecret456',
+                        },
+                        f,
+                    )
 
                 import importlib
 
                 import api
+
                 importlib.reload(api)
 
                 api.app.config['TESTING'] = True

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -8,60 +8,60 @@ import responses
 
 class TestFetchPostsJson:
     """Tests for fetch_posts_json function."""
-    
+
     @responses.activate
     def test_fetch_posts_json_success(self, mock_json_response):
         """Test successful fetch from JSON endpoint."""
         from bot import fetch_posts_json
-        
+
         responses.add(
             responses.GET,
             'https://old.reddit.com/r/hardwareswap/new.json?limit=10',
             json=mock_json_response,
             status=200
         )
-        
+
         posts = fetch_posts_json('hardwareswap', limit=10)
-        
+
         assert posts is not None
         assert len(posts) == 2
         assert posts[0]['id'] == 'post1'
         assert posts[0]['title'] == '[USA-NY] [H] RTX 4090 FE [W] PayPal'
         assert posts[0]['score'] == 25
         assert posts[1]['id'] == 'post2'
-    
+
     @responses.activate
     def test_fetch_posts_json_rate_limited(self):
         """Test handling of rate limit (429) response."""
         from bot import fetch_posts_json
-        
+
         responses.add(
             responses.GET,
             'https://old.reddit.com/r/hardwareswap/new.json?limit=10',
             status=429
         )
-        
+
         posts = fetch_posts_json('hardwareswap', limit=10)
         assert posts is None
-    
+
     @responses.activate
     def test_fetch_posts_json_forbidden(self):
         """Test handling of forbidden (403) response."""
         from bot import fetch_posts_json
-        
+
         responses.add(
             responses.GET,
             'https://old.reddit.com/r/hardwareswap/new.json?limit=10',
             status=403
         )
-        
+
         posts = fetch_posts_json('hardwareswap', limit=10)
         assert posts is None
 
 
 class TestCredentialValidation:
     """Tests for credential validation in api.py (not bot.py)."""
-    
+
     # These tests are NOT skipped since they test api.py which doesn't block
     pass
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3,6 +3,7 @@
 bot.py no longer does blocking/auth work at import time (the data-source helpers
 live in the reddit_scraper package and are re-exported by bot), so these run normally.
 """
+
 import responses
 
 
@@ -18,7 +19,7 @@ class TestFetchPostsJson:
             responses.GET,
             'https://old.reddit.com/r/hardwareswap/new.json?limit=10',
             json=mock_json_response,
-            status=200
+            status=200,
         )
 
         posts = fetch_posts_json('hardwareswap', limit=10)
@@ -35,11 +36,7 @@ class TestFetchPostsJson:
         """Test handling of rate limit (429) response."""
         from bot import fetch_posts_json
 
-        responses.add(
-            responses.GET,
-            'https://old.reddit.com/r/hardwareswap/new.json?limit=10',
-            status=429
-        )
+        responses.add(responses.GET, 'https://old.reddit.com/r/hardwareswap/new.json?limit=10', status=429)
 
         posts = fetch_posts_json('hardwareswap', limit=10)
         assert posts is None
@@ -49,11 +46,7 @@ class TestFetchPostsJson:
         """Test handling of forbidden (403) response."""
         from bot import fetch_posts_json
 
-        responses.add(
-            responses.GET,
-            'https://old.reddit.com/r/hardwareswap/new.json?limit=10',
-            status=403
-        )
+        responses.add(responses.GET, 'https://old.reddit.com/r/hardwareswap/new.json?limit=10', status=403)
 
         posts = fetch_posts_json('hardwareswap', limit=10)
         assert posts is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 """Tests for source-order resolution (reddit_scraper.config)."""
+
 import pytest
 
 from reddit_scraper import config
@@ -12,7 +13,6 @@ def reset_order():
 
 
 class TestSourceOrder:
-
     def test_default_when_unset(self):
         config.set_source_order(None)
         assert config.get_source_order() == ['oauth', 'json', 'rss']
@@ -33,7 +33,6 @@ class TestSourceOrder:
 
 
 class TestApplySourceOrderFromConfig:
-
     def test_config_source_order_takes_precedence_over_env(self, monkeypatch):
         monkeypatch.setenv('REDDIT_SOURCE_ORDER', 'json,rss')
         config.apply_source_order_from_config({'source_order': ['rss']})

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,4 +1,5 @@
 """Tests for credential validation in api.py."""
+
 from unittest.mock import patch
 
 
@@ -15,7 +16,7 @@ class TestCredentialValidation:
             client_secret='IaYQJWІRqNCg',  # Contains Cyrillic І at position 6
             username='testuser',
             password='testpass',
-            user_agent='TestAgent/1.0'
+            user_agent='TestAgent/1.0',
         )
 
         assert success is False
@@ -31,7 +32,7 @@ class TestCredentialValidation:
             client_secret='testsecret',
             username='testuser',
             password='testpass',
-            user_agent='TestAgent/1.0'
+            user_agent='TestAgent/1.0',
         )
 
         assert success is False
@@ -50,7 +51,7 @@ class TestCredentialValidation:
                 client_secret='validascii456',
                 username='testuser',
                 password='testpass',
-                user_agent='TestAgent/1.0'
+                user_agent='TestAgent/1.0',
             )
 
             # Should fail due to OAuth, not ASCII check

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,15 +1,14 @@
 """Tests for credential validation in api.py."""
-import pytest
 from unittest.mock import patch
 
 
 class TestCredentialValidation:
     """Tests for credential validation."""
-    
+
     def test_non_ascii_detection(self):
         """Test that non-ASCII characters are detected in credentials."""
         from api import validate_reddit_credentials
-        
+
         # Cyrillic 'І' looks like Latin 'I' but has different code point
         success, error = validate_reddit_credentials(
             client_id='test123',
@@ -18,15 +17,15 @@ class TestCredentialValidation:
             password='testpass',
             user_agent='TestAgent/1.0'
         )
-        
+
         assert success is False
         assert 'Non-ASCII' in error or 'non-ASCII' in error.lower()
         assert 'client_secret' in error
-    
+
     def test_empty_credentials_fail(self):
         """Test that empty credentials fail validation."""
         from api import validate_reddit_credentials
-        
+
         success, error = validate_reddit_credentials(
             client_id='',
             client_secret='testsecret',
@@ -34,18 +33,18 @@ class TestCredentialValidation:
             password='testpass',
             user_agent='TestAgent/1.0'
         )
-        
+
         assert success is False
-    
+
     def test_ascii_credentials_try_oauth(self):
         """Test that pure ASCII credentials attempt OAuth validation."""
         from api import validate_reddit_credentials
-        
+
         with patch('api.requests.post') as mock_post:
             # Simulate OAuth failure (which is expected for fake creds)
             mock_post.return_value.status_code = 401
             mock_post.return_value.json.return_value = {'error': 'invalid_grant'}
-            
+
             success, error = validate_reddit_credentials(
                 client_id='validascii123',
                 client_secret='validascii456',
@@ -53,7 +52,7 @@ class TestCredentialValidation:
                 password='testpass',
                 user_agent='TestAgent/1.0'
             )
-            
+
             # Should fail due to OAuth, not ASCII check
             assert 'Non-ASCII' not in (error or '')
             # OAuth attempt was made

--- a/tests/test_credentials_pkg.py
+++ b/tests/test_credentials_pkg.py
@@ -14,6 +14,18 @@ def restore_state():
     credentials.CREDENTIAL_WARNING = saved_warning
 
 
+class TestFindNonAscii:
+
+    def test_flags_position_and_char(self):
+        hits = credentials.find_non_ascii('IaYQJWІRqNCg')  # Cyrillic І at index 6
+        assert hits == [(6, 'І')]
+
+    def test_clean_and_empty_are_empty(self):
+        assert credentials.find_non_ascii('plain-ascii') == []
+        assert credentials.find_non_ascii('') == []
+        assert credentials.find_non_ascii(None) == []
+
+
 class TestCheckCredentialEncoding:
 
     def test_detects_cyrillic_lookalike(self):

--- a/tests/test_credentials_pkg.py
+++ b/tests/test_credentials_pkg.py
@@ -1,5 +1,6 @@
 """Tests for credential loading, the encoding guard, and PRAW auth modes
 (reddit_scraper.credentials)."""
+
 import pytest
 
 from reddit_scraper import credentials
@@ -15,7 +16,6 @@ def restore_state():
 
 
 class TestFindNonAscii:
-
     def test_flags_position_and_char(self):
         hits = credentials.find_non_ascii('IaYQJWІRqNCg')  # Cyrillic І at index 6
         assert hits == [(6, 'І')]
@@ -27,7 +27,6 @@ class TestFindNonAscii:
 
 
 class TestCheckCredentialEncoding:
-
     def test_detects_cyrillic_lookalike(self):
         creds = {'reddit_client_secret': 'IaYQJWІRqNCg'}  # Cyrillic І at index 6
         offenders = credentials.check_credential_encoding(creds)
@@ -37,15 +36,17 @@ class TestCheckCredentialEncoding:
 
     def test_clean_credentials_clear_warning(self):
         credentials.CREDENTIAL_WARNING = "stale warning"
-        offenders = credentials.check_credential_encoding({
-            'reddit_client_id': 'abc', 'reddit_client_secret': 'def',
-        })
+        offenders = credentials.check_credential_encoding(
+            {
+                'reddit_client_id': 'abc',
+                'reddit_client_secret': 'def',
+            }
+        )
         assert offenders == []
         assert credentials.CREDENTIAL_WARNING is None
 
 
 class TestLoadCredentials:
-
     def test_env_fallback_when_no_file(self, monkeypatch):
         monkeypatch.setattr(credentials.config, 'get_credentials_path', lambda: '/nonexistent/creds.json')
         monkeypatch.setenv('REDDIT_CLIENT_ID', 'env_id')
@@ -57,14 +58,14 @@ class TestLoadCredentials:
 
 
 class TestAuthenticateReddit:
-
     def test_returns_none_without_app_credentials(self):
         credentials.CREDENTIALS = {'reddit_client_id': None, 'reddit_client_secret': None}
         assert credentials.authenticate_reddit() is None
 
     def test_app_only_is_read_only(self):
         credentials.CREDENTIALS = {
-            'reddit_client_id': 'id', 'reddit_client_secret': 'secret',
+            'reddit_client_id': 'id',
+            'reddit_client_secret': 'secret',
             'reddit_user_agent': 'ua/1.0',
         }
         reddit = credentials.authenticate_reddit()
@@ -73,9 +74,11 @@ class TestAuthenticateReddit:
 
     def test_full_login_is_not_read_only(self):
         credentials.CREDENTIALS = {
-            'reddit_client_id': 'id', 'reddit_client_secret': 'secret',
+            'reddit_client_id': 'id',
+            'reddit_client_secret': 'secret',
             'reddit_user_agent': 'ua/1.0',
-            'reddit_username': 'user', 'reddit_password': 'pass',
+            'reddit_username': 'user',
+            'reddit_password': 'pass',
         }
         reddit = credentials.authenticate_reddit()
         assert reddit is not None

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -43,7 +43,7 @@ class TestFallbackHeartbeat:
         monkeypatch.setenv('KUMA_FALLBACK_PUSH_URL', 'http://kuma/api/push/FB')
         credentials.CREDENTIALS = {'reddit_client_id': 'a', 'reddit_client_secret': 'b'}
         config.set_source_order(['oauth', 'rss', 'json'])
-        sources._active_source = 'rss'
+        sources._state.active_source = 'rss'
         health.send_kuma_fallback_heartbeat()
         assert captured[0][1]['status'] == 'down'
 
@@ -51,14 +51,14 @@ class TestFallbackHeartbeat:
         monkeypatch.setenv('KUMA_FALLBACK_PUSH_URL', 'http://kuma/api/push/FB')
         credentials.CREDENTIALS = {'reddit_client_id': 'a', 'reddit_client_secret': 'b'}
         config.set_source_order(['oauth', 'rss', 'json'])
-        sources._active_source = 'oauth'
+        sources._state.active_source = 'oauth'
         health.send_kuma_fallback_heartbeat()
         assert captured[0][1]['status'] == 'up'
 
     def test_up_when_rss_is_intended(self, captured, monkeypatch):
         monkeypatch.setenv('KUMA_FALLBACK_PUSH_URL', 'http://kuma/api/push/FB')
         credentials.CREDENTIALS = {}            # no app -> RSS is by configuration
-        sources._active_source = 'rss'
+        sources._state.active_source = 'rss'
         health.send_kuma_fallback_heartbeat()
         assert captured[0][1]['status'] == 'up'
 
@@ -71,19 +71,19 @@ class TestPrimaryHeartbeat:
 
     def test_up_on_recent_success(self, captured, monkeypatch):
         monkeypatch.setenv('KUMA_PUSH_URL', 'http://kuma/api/push/MAIN')
-        sources._LAST_FETCH_SUCCESS_TS = time.time()
+        sources._state.last_fetch_success_ts = time.time()
         health.send_kuma_heartbeat()
         assert captured[0][1]['status'] == 'up'
 
     def test_down_when_never_succeeded(self, captured, monkeypatch):
         monkeypatch.setenv('KUMA_PUSH_URL', 'http://kuma/api/push/MAIN')
-        sources._LAST_FETCH_SUCCESS_TS = None
+        sources._state.last_fetch_success_ts = None
         health.send_kuma_heartbeat()
         assert captured[0][1]['status'] == 'down'
 
     def test_down_when_stale(self, captured, monkeypatch):
         monkeypatch.setenv('KUMA_PUSH_URL', 'http://kuma/api/push/MAIN')
         monkeypatch.setenv('KUMA_FETCH_STALE_SECONDS', '60')
-        sources._LAST_FETCH_SUCCESS_TS = time.time() - 600
+        sources._state.last_fetch_success_ts = time.time() - 600
         health.send_kuma_heartbeat()
         assert captured[0][1]['status'] == 'down'

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -3,7 +3,7 @@ import time
 
 import pytest
 
-from reddit_scraper import health, credentials, config, sources
+from reddit_scraper import config, credentials, health, sources
 
 
 @pytest.fixture

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,4 +1,5 @@
 """Tests for Uptime Kuma heartbeats (reddit_scraper.health)."""
+
 import time
 
 import pytest
@@ -20,7 +21,6 @@ def captured(monkeypatch):
 
 
 class TestOauthExpected:
-
     def test_true_when_app_creds_and_oauth_in_order(self):
         credentials.CREDENTIALS = {'reddit_client_id': 'a', 'reddit_client_secret': 'b'}
         config.set_source_order(['oauth', 'rss'])
@@ -38,7 +38,6 @@ class TestOauthExpected:
 
 
 class TestFallbackHeartbeat:
-
     def test_down_when_oauth_expected_but_on_fallback(self, captured, monkeypatch):
         monkeypatch.setenv('KUMA_FALLBACK_PUSH_URL', 'http://kuma/api/push/FB')
         credentials.CREDENTIALS = {'reddit_client_id': 'a', 'reddit_client_secret': 'b'}
@@ -57,7 +56,7 @@ class TestFallbackHeartbeat:
 
     def test_up_when_rss_is_intended(self, captured, monkeypatch):
         monkeypatch.setenv('KUMA_FALLBACK_PUSH_URL', 'http://kuma/api/push/FB')
-        credentials.CREDENTIALS = {}            # no app -> RSS is by configuration
+        credentials.CREDENTIALS = {}  # no app -> RSS is by configuration
         sources._state.active_source = 'rss'
         health.send_kuma_fallback_heartbeat()
         assert captured[0][1]['status'] == 'up'
@@ -68,7 +67,6 @@ class TestFallbackHeartbeat:
 
 
 class TestPrimaryHeartbeat:
-
     def test_up_on_recent_success(self, captured, monkeypatch):
         monkeypatch.setenv('KUMA_PUSH_URL', 'http://kuma/api/push/MAIN')
         sources._state.last_fetch_success_ts = time.time()

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,4 +1,5 @@
 """Tests for post filtering in RedditMonitor._process_post (reddit_scraper.monitor)."""
+
 from unittest.mock import MagicMock
 
 from reddit_scraper.monitor import RedditMonitor
@@ -22,14 +23,22 @@ def make_monitor(keywords=('4090',), **overrides):
     return m
 
 
-def process(m, *, post_id='p1', title='RTX 4090 for sale', score=50,
-            domain='ebay.com', flair='SELLING', author='seller1'):
-    return m._process_post(post_id=post_id, title=title, url='http://x', score=score,
-                           permalink='/r/x/p1/', domain=domain, flair=flair, author=author)
+def process(
+    m, *, post_id='p1', title='RTX 4090 for sale', score=50, domain='ebay.com', flair='SELLING', author='seller1'
+):
+    return m._process_post(
+        post_id=post_id,
+        title=title,
+        url='http://x',
+        score=score,
+        permalink='/r/x/p1/',
+        domain=domain,
+        flair=flair,
+        author=author,
+    )
 
 
 class TestProcessPost:
-
     def test_basic_match_notifies(self):
         m = make_monitor()
         assert process(m) is True

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,4 +1,5 @@
 """Tests for the data-source pathways and dispatcher (reddit_scraper.sources)."""
+
 import pytest
 import responses
 
@@ -8,12 +9,12 @@ from reddit_scraper import config, sources
 @pytest.fixture(autouse=True)
 def reset_source_state():
     """Source state is module-global; reset it (and disable RSS throttling/caching) per test."""
-    sources._state.reset()          # fresh runtime state (cooldowns, cache, proxy, flags)
+    sources._state.reset()  # fresh runtime state (cooldowns, cache, proxy, flags)
     sources.RSS_MIN_INTERVAL = 0
-    sources.FETCH_CACHE_TTL = 0     # disable caching by default; coalescing tests opt back in
-    sources._PROXIES = []           # no proxy by default; proxy tests opt back in
-    sources.SYLVIA_API_KEY = None   # sylvia disabled by default; its tests set a key
-    config.set_source_order(None)   # back to default oauth -> json -> rss
+    sources.FETCH_CACHE_TTL = 0  # disable caching by default; coalescing tests opt back in
+    sources._PROXIES = []  # no proxy by default; proxy tests opt back in
+    sources.SYLVIA_API_KEY = None  # sylvia disabled by default; its tests set a key
+    config.set_source_order(None)  # back to default oauth -> json -> rss
     yield
 
 
@@ -47,22 +48,20 @@ COMMENT_FEED = b'''<?xml version="1.0" encoding="UTF-8"?>
 
 
 class TestFetchPostsRss:
-
     @responses.activate
     def test_parses_and_normalizes_fields(self):
-        responses.add(responses.GET, 'https://www.reddit.com/r/gamedeals/new/.rss',
-                      body=POST_FEED, status=200)
+        responses.add(responses.GET, 'https://www.reddit.com/r/gamedeals/new/.rss', body=POST_FEED, status=200)
         posts = sources.fetch_posts_rss('gamedeals', limit=10)
 
         assert len(posts) == 1
         p = posts[0]
-        assert p['id'] == 'abc123'                       # t3_ prefix stripped
+        assert p['id'] == 'abc123'  # t3_ prefix stripped
         assert p['title'] == 'Red Dead Redemption 75% off'
-        assert p['author'] == 'dealhunter'               # /u/ stripped
-        assert p['link_flair_text'] == 'Expired'         # from <category term=...>
+        assert p['author'] == 'dealhunter'  # /u/ stripped
+        assert p['link_flair_text'] == 'Expired'  # from <category term=...>
         assert p['permalink'] == '/r/gamedeals/comments/abc123/red_dead_redemption_75_off/'
-        assert p['score'] == 0                            # not exposed via RSS
-        assert p['domain'] == ''                          # not exposed via RSS
+        assert p['score'] == 0  # not exposed via RSS
+        assert p['domain'] == ''  # not exposed via RSS
 
     @responses.activate
     def test_raises_on_403(self):
@@ -78,23 +77,31 @@ class TestFetchPostsRss:
 
 
 class TestFetchThreadCommentsRss:
-
     @responses.activate
     def test_filters_post_entry_and_strips_html(self):
-        responses.add(responses.GET, 'https://www.reddit.com/r/x/comments/abc123/.rss',
-                      body=COMMENT_FEED, status=200)
+        responses.add(responses.GET, 'https://www.reddit.com/r/x/comments/abc123/.rss', body=COMMENT_FEED, status=200)
         comments = sources.fetch_thread_comments_rss('x', 'abc123')
 
-        assert len(comments) == 1                          # the t3_ post entry is skipped
+        assert len(comments) == 1  # the t3_ post entry is skipped
         c = comments[0]
         assert c['id'] == 'def456'
         assert c['author'] == 'seller'
-        assert c['body'] == 'WTS shirt size Small $20'      # HTML tags stripped
+        assert c['body'] == 'WTS shirt size Small $20'  # HTML tags stripped
 
 
 def _post():
-    return [{'id': '1', 'title': 't', 'url': '', 'score': 0,
-             'permalink': '/p', 'domain': '', 'link_flair_text': '', 'author': 'a'}]
+    return [
+        {
+            'id': '1',
+            'title': 't',
+            'url': '',
+            'score': 0,
+            'permalink': '/p',
+            'domain': '',
+            'link_flair_text': '',
+            'author': 'a',
+        }
+    ]
 
 
 def _raises(*a, **k):
@@ -109,7 +116,7 @@ class TestFetchPostsDispatcher:
         monkeypatch.setattr(sources, 'fetch_posts_json', lambda sub, lim: _post())
         monkeypatch.setattr(sources, 'fetch_posts_rss', lambda sub, lim: _post())
         posts, source = sources.fetch_posts('gamedeals', 10, reddit=None)
-        assert source == 'json'          # oauth skipped (no reddit), json is next
+        assert source == 'json'  # oauth skipped (no reddit), json is next
         assert sources.get_active_source() == 'json'
 
     def test_falls_through_on_failure_and_cools_down(self, monkeypatch):
@@ -119,7 +126,7 @@ class TestFetchPostsDispatcher:
         posts, source = sources.fetch_posts('gamedeals', 10, reddit=None)
         assert source == 'rss'
         assert posts == []
-        assert not sources._source_available('json')       # failed source on cooldown
+        assert not sources._source_available('json')  # failed source on cooldown
 
     def test_returns_none_when_all_sources_fail(self, monkeypatch):
         config.set_source_order(['json', 'rss'])
@@ -136,10 +143,11 @@ class TestFetchPostsDispatcher:
         def json_fetch(sub, lim):
             called['json'] = True
             return _post()
+
         monkeypatch.setattr(sources, 'fetch_posts_json', json_fetch)
         monkeypatch.setattr(sources, 'fetch_posts_rss', lambda sub, lim: _post())
         posts, source = sources.fetch_posts('gamedeals', 10, reddit=None)
-        assert source == 'rss'           # json skipped due to cooldown
+        assert source == 'rss'  # json skipped due to cooldown
         assert called['json'] is False
 
     def test_oauth_success_sets_active_source_and_records_success(self, monkeypatch):
@@ -151,13 +159,15 @@ class TestFetchPostsDispatcher:
 
 
 class TestAuthErrorNotificationGuard:
-
     def test_concurrent_401s_notify_only_once(self, monkeypatch):
         """6 monitors hitting the same OAuth 401 in parallel must produce one alert."""
         from concurrent.futures import ThreadPoolExecutor
 
-        monkeypatch.setattr(sources, '_fetch_posts_oauth',
-                            lambda reddit, sub, lim: (_ for _ in ()).throw(RuntimeError("received 401 HTTP response")))
+        monkeypatch.setattr(
+            sources,
+            '_fetch_posts_oauth',
+            lambda reddit, sub, lim: (_ for _ in ()).throw(RuntimeError("received 401 HTTP response")),
+        )
         # next source serves so the chain completes (stub both to avoid the network)
         monkeypatch.setattr(sources, 'fetch_posts_json', lambda sub, lim: _post())
         monkeypatch.setattr(sources, 'fetch_posts_rss', lambda sub, lim: _post())
@@ -172,7 +182,6 @@ class TestAuthErrorNotificationGuard:
 
 
 class TestCoalescing:
-
     def test_duplicate_subreddit_shares_one_request(self, monkeypatch):
         sources.FETCH_CACHE_TTL = 90
         calls = {'n': 0}
@@ -180,23 +189,26 @@ class TestCoalescing:
         def served(sub, lim):
             calls['n'] += 1
             return _post()
+
         monkeypatch.setattr(sources, 'fetch_posts_json', served)
 
         r1 = sources.fetch_posts('frugalmalefashion', 10, None)
         r2 = sources.fetch_posts('frugalmalefashion', 10, None)
-        assert calls['n'] == 1          # second served from cache
+        assert calls['n'] == 1  # second served from cache
         assert r1 == r2
 
     def test_concurrent_duplicates_coalesce_to_one(self, monkeypatch):
         import time
         from concurrent.futures import ThreadPoolExecutor
+
         sources.FETCH_CACHE_TTL = 90
         calls = {'n': 0}
 
         def served(sub, lim):
             calls['n'] += 1
-            time.sleep(0.05)            # widen the race window
+            time.sleep(0.05)  # widen the race window
             return _post()
+
         monkeypatch.setattr(sources, 'fetch_posts_json', served)
 
         with ThreadPoolExecutor(max_workers=5) as ex:
@@ -206,8 +218,9 @@ class TestCoalescing:
     def test_different_subreddits_not_shared(self, monkeypatch):
         sources.FETCH_CACHE_TTL = 90
         calls = {'n': 0}
-        monkeypatch.setattr(sources, 'fetch_posts_json',
-                            lambda sub, lim: (calls.__setitem__('n', calls['n'] + 1) or _post()))
+        monkeypatch.setattr(
+            sources, 'fetch_posts_json', lambda sub, lim: calls.__setitem__('n', calls['n'] + 1) or _post()
+        )
         sources.fetch_posts('gamedeals', 10, None)
         sources.fetch_posts('apphookup', 10, None)
         assert calls['n'] == 2
@@ -218,25 +231,27 @@ class TestCoalescing:
         config.set_source_order(['json', 'rss'])
         json_calls = {'n': 0}
         rss_calls = {'n': 0}
-        monkeypatch.setattr(sources, 'fetch_posts_json',
-                            lambda sub, lim: (json_calls.__setitem__('n', json_calls['n'] + 1) or _raises()))
-        monkeypatch.setattr(sources, 'fetch_posts_rss',
-                            lambda sub, lim: (rss_calls.__setitem__('n', rss_calls['n'] + 1) or _post()))
+        monkeypatch.setattr(
+            sources, 'fetch_posts_json', lambda sub, lim: json_calls.__setitem__('n', json_calls['n'] + 1) or _raises()
+        )
+        monkeypatch.setattr(
+            sources, 'fetch_posts_rss', lambda sub, lim: rss_calls.__setitem__('n', rss_calls['n'] + 1) or _post()
+        )
         sources.fetch_posts('gamedeals', 10, None)
         sources.fetch_posts('gamedeals', 10, None)
-        assert json_calls['n'] == 1 and rss_calls['n'] == 1   # whole chain ran once, then cached
+        assert json_calls['n'] == 1 and rss_calls['n'] == 1  # whole chain ran once, then cached
 
 
 class TestBackoff:
-
     def test_exponential_backoff_on_consecutive_failures(self):
         import time
-        sources._mark_source_down('rss')                       # 1st: base (300s)
+
+        sources._mark_source_down('rss')  # 1st: base (300s)
         first = sources._state.source_cooldown_until['rss'] - time.time()
-        sources._mark_source_down('rss')                       # 2nd: 2x (600s)
+        sources._mark_source_down('rss')  # 2nd: 2x (600s)
         second = sources._state.source_cooldown_until['rss'] - time.time()
         assert 290 < first <= sources.SOURCE_COOLDOWN_SECONDS
-        assert second > first * 1.5                            # roughly doubled
+        assert second > first * 1.5  # roughly doubled
 
     def test_success_resets_backoff(self):
         sources._mark_source_down('rss')
@@ -248,6 +263,7 @@ class TestBackoff:
     def test_backoff_capped(self, monkeypatch):
         monkeypatch.setattr(sources, 'SOURCE_COOLDOWN_MAX', 1000)
         import time
+
         for _ in range(10):
             sources._mark_source_down('rss')
         assert sources._state.source_cooldown_until['rss'] - time.time() <= 1000
@@ -258,7 +274,6 @@ class TestBackoff:
 
 
 class TestProxying:
-
     def _record_get(self, monkeypatch):
         """Replace requests.get with a recorder returning a trivial 200 response."""
         calls = []
@@ -266,8 +281,12 @@ class TestProxying:
         class _Resp:
             status_code = 200
             content = POST_FEED
-            def raise_for_status(self): pass
-            def json(self): return {'data': {'children': []}}
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {'data': {'children': []}}
 
         def fake_get(url, headers=None, timeout=None, proxies=None):
             calls.append(proxies)
@@ -279,14 +298,13 @@ class TestProxying:
     def test_no_proxy_makes_direct_request(self, monkeypatch):
         calls = self._record_get(monkeypatch)
         sources.fetch_posts_rss('gamedeals')
-        assert calls == [None]                                  # proxies kwarg never passed
+        assert calls == [None]  # proxies kwarg never passed
 
     def test_single_proxy_is_used(self, monkeypatch):
         calls = self._record_get(monkeypatch)
         sources._PROXIES = ['http://proxy.local:8000']
         sources.fetch_posts_rss('gamedeals')
-        assert calls == [{'http': 'http://proxy.local:8000',
-                          'https': 'http://proxy.local:8000'}]
+        assert calls == [{'http': 'http://proxy.local:8000', 'https': 'http://proxy.local:8000'}]
 
     def test_pool_rotates_across_requests(self, monkeypatch):
         calls = self._record_get(monkeypatch)
@@ -304,7 +322,9 @@ class TestProxying:
         class _Resp:
             status_code = 200
             content = POST_FEED
-            def raise_for_status(self): pass
+
+            def raise_for_status(self):
+                pass
 
         def fake_get(url, headers=None, timeout=None, proxies=None):
             attempts.append(proxies['http'])
@@ -315,7 +335,7 @@ class TestProxying:
         monkeypatch.setattr(sources.requests, 'get', fake_get)
         posts = sources.fetch_posts_rss('gamedeals')
         assert attempts == ['http://dead:8000', 'http://good:8000']
-        assert 'http://dead:8000' in sources._state.proxy_cooldown_until   # cooled down
+        assert 'http://dead:8000' in sources._state.proxy_cooldown_until  # cooled down
         assert posts is not None
 
     def test_all_proxies_down_raises_no_direct_leak(self, monkeypatch):
@@ -337,30 +357,51 @@ class TestProxying:
 
 SYLVIA_POSTS = {
     "success": True,
-    "data": {"after": "t3_zzz", "posts": [
-        {"id": "abc123", "title": "Red Dead Redemption 75% off",
-         "url": "https://store.example.com/x", "score": 42,
-         "permalink": "/r/gamedeals/comments/abc123/rdr/", "domain": "store.example.com",
-         "link_flair_text": None, "author": "dealhunter"},
-    ]},
+    "data": {
+        "after": "t3_zzz",
+        "posts": [
+            {
+                "id": "abc123",
+                "title": "Red Dead Redemption 75% off",
+                "url": "https://store.example.com/x",
+                "score": 42,
+                "permalink": "/r/gamedeals/comments/abc123/rdr/",
+                "domain": "store.example.com",
+                "link_flair_text": None,
+                "author": "dealhunter",
+            },
+        ],
+    },
 }
 
 SYLVIA_THREAD = {
     "success": True,
-    "data": {"thread": [
-        {"data": {"children": [{"kind": "t3", "data": {"id": "abc123", "title": "the post"}}]}},
-        {"data": {"children": [
-            {"kind": "t1", "data": {"id": "def456", "body": "WTS shirt $20",
-                                    "author": "seller", "score": 3,
-                                    "permalink": "/r/x/comments/abc123/_/def456/"}},
-            {"kind": "more", "data": {"id": "ghi789"}},
-        ]}},
-    ]},
+    "data": {
+        "thread": [
+            {"data": {"children": [{"kind": "t3", "data": {"id": "abc123", "title": "the post"}}]}},
+            {
+                "data": {
+                    "children": [
+                        {
+                            "kind": "t1",
+                            "data": {
+                                "id": "def456",
+                                "body": "WTS shirt $20",
+                                "author": "seller",
+                                "score": 3,
+                                "permalink": "/r/x/comments/abc123/_/def456/",
+                            },
+                        },
+                        {"kind": "more", "data": {"id": "ghi789"}},
+                    ]
+                }
+            },
+        ]
+    },
 }
 
 
 class TestSylvia:
-
     BASE = 'https://api.sylvia-api.com/v1/reddit'
 
     @responses.activate
@@ -372,28 +413,26 @@ class TestSylvia:
         assert len(posts) == 1
         p = posts[0]
         assert p['id'] == 'abc123'
-        assert p['score'] == 42                       # full data, unlike RSS
+        assert p['score'] == 42  # full data, unlike RSS
         assert p['domain'] == 'store.example.com'
-        assert p['link_flair_text'] == ''             # None normalized to ''
+        assert p['link_flair_text'] == ''  # None normalized to ''
         # the key is sent in the X-API-KEY header
         assert responses.calls[0].request.headers['X-API-KEY'] == 'syl_test'
 
     @responses.activate
     def test_comments_read_second_listing_t1_only(self):
         sources.SYLVIA_API_KEY = 'syl_test'
-        responses.add(responses.GET, f'{self.BASE}/submission/abc123/full',
-                      json=SYLVIA_THREAD, status=200)
+        responses.add(responses.GET, f'{self.BASE}/submission/abc123/full', json=SYLVIA_THREAD, status=200)
         comments = sources.fetch_thread_comments_sylvia('x', 'abc123')
 
-        assert len(comments) == 1                     # 'more' child dropped, post listing ignored
+        assert len(comments) == 1  # 'more' child dropped, post listing ignored
         assert comments[0]['id'] == 'def456'
         assert comments[0]['author'] == 'seller'
 
     @responses.activate
     def test_auth_failure_raises_for_backoff(self):
         sources.SYLVIA_API_KEY = 'syl_bad'
-        responses.add(responses.GET, f'{self.BASE}/r/gamedeals/new',
-                      json={"error": {"code": "FORBIDDEN"}}, status=403)
+        responses.add(responses.GET, f'{self.BASE}/r/gamedeals/new', json={"error": {"code": "FORBIDDEN"}}, status=403)
         with pytest.raises(RuntimeError):
             sources.fetch_posts_sylvia('gamedeals')
 
@@ -406,9 +445,9 @@ class TestSylvia:
 
     def test_source_skipped_when_no_key(self):
         sources.SYLVIA_API_KEY = None
-        config.set_source_order(['sylvia'])           # only sylvia, but no key
+        config.set_source_order(['sylvia'])  # only sylvia, but no key
         posts, source = sources.fetch_posts('gamedeals', 10, reddit=None)
-        assert (posts, source) == (None, None)        # skipped, never requested
+        assert (posts, source) == (None, None)  # skipped, never requested
 
     @responses.activate
     def test_dispatcher_uses_sylvia_when_ordered_and_keyed(self, monkeypatch):
@@ -416,7 +455,6 @@ class TestSylvia:
         config.set_source_order(['sylvia', 'json'])
         responses.add(responses.GET, f'{self.BASE}/r/gamedeals/new', json=SYLVIA_POSTS, status=200)
         # json must not be reached if sylvia succeeds
-        monkeypatch.setattr(sources, 'fetch_posts_json',
-                            lambda *a, **k: pytest.fail("json should not be called"))
+        monkeypatch.setattr(sources, 'fetch_posts_json', lambda *a, **k: pytest.fail("json should not be called"))
         posts, source = sources.fetch_posts('gamedeals', 10, reddit=None)
         assert source == 'sylvia' and posts[0]['id'] == 'abc123'

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -2,7 +2,7 @@
 import pytest
 import responses
 
-from reddit_scraper import sources, config
+from reddit_scraper import config, sources
 
 
 @pytest.fixture(autouse=True)
@@ -188,8 +188,8 @@ class TestCoalescing:
         assert r1 == r2
 
     def test_concurrent_duplicates_coalesce_to_one(self, monkeypatch):
-        from concurrent.futures import ThreadPoolExecutor
         import time
+        from concurrent.futures import ThreadPoolExecutor
         sources.FETCH_CACHE_TTL = 90
         calls = {'n': 0}
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -8,22 +8,12 @@ from reddit_scraper import sources, config
 @pytest.fixture(autouse=True)
 def reset_source_state():
     """Source state is module-global; reset it (and disable RSS throttling/caching) per test."""
-    sources._source_cooldown_until.clear()
-    sources._source_failures.clear()
-    sources._fetch_cache.clear()
-    sources._fetch_key_locks.clear()
-    sources._active_source = None
-    sources._LAST_FETCH_SUCCESS_TS = None
-    sources._auth_error_notified = False
-    sources._rss_last_request[0] = 0.0
+    sources._state.reset()          # fresh runtime state (cooldowns, cache, proxy, flags)
     sources.RSS_MIN_INTERVAL = 0
-    sources.FETCH_CACHE_TTL = 0  # disable caching by default; coalescing tests opt back in
-    sources._PROXIES = []        # no proxy by default; proxy tests opt back in
-    sources._proxy_index[0] = 0
-    sources._proxy_cooldown_until.clear()
+    sources.FETCH_CACHE_TTL = 0     # disable caching by default; coalescing tests opt back in
+    sources._PROXIES = []           # no proxy by default; proxy tests opt back in
     sources.SYLVIA_API_KEY = None   # sylvia disabled by default; its tests set a key
-    sources._sylvia_key_warned = False
-    config.set_source_order(None)  # back to default oauth -> json -> rss
+    config.set_source_order(None)   # back to default oauth -> json -> rss
     yield
 
 
@@ -120,7 +110,7 @@ class TestFetchPostsDispatcher:
         monkeypatch.setattr(sources, 'fetch_posts_rss', lambda sub, lim: _post())
         posts, source = sources.fetch_posts('gamedeals', 10, reddit=None)
         assert source == 'json'          # oauth skipped (no reddit), json is next
-        assert sources._active_source == 'json'
+        assert sources.get_active_source() == 'json'
 
     def test_falls_through_on_failure_and_cools_down(self, monkeypatch):
         config.set_source_order(['json', 'rss'])
@@ -156,8 +146,8 @@ class TestFetchPostsDispatcher:
         monkeypatch.setattr(sources, '_fetch_posts_oauth', lambda r, sub, lim: _post())
         posts, source = sources.fetch_posts('gamedeals', 10, reddit=object())
         assert source == 'oauth'
-        assert sources._active_source == 'oauth'
-        assert sources._LAST_FETCH_SUCCESS_TS is not None
+        assert sources.get_active_source() == 'oauth'
+        assert sources.get_last_fetch_success_ts() is not None
 
 
 class TestAuthErrorNotificationGuard:
@@ -242,29 +232,29 @@ class TestBackoff:
     def test_exponential_backoff_on_consecutive_failures(self):
         import time
         sources._mark_source_down('rss')                       # 1st: base (300s)
-        first = sources._source_cooldown_until['rss'] - time.time()
+        first = sources._state.source_cooldown_until['rss'] - time.time()
         sources._mark_source_down('rss')                       # 2nd: 2x (600s)
-        second = sources._source_cooldown_until['rss'] - time.time()
+        second = sources._state.source_cooldown_until['rss'] - time.time()
         assert 290 < first <= sources.SOURCE_COOLDOWN_SECONDS
         assert second > first * 1.5                            # roughly doubled
 
     def test_success_resets_backoff(self):
         sources._mark_source_down('rss')
         sources._mark_source_down('rss')
-        assert sources._source_failures['rss'] == 2
+        assert sources._state.source_failures['rss'] == 2
         sources._note_source_success('rss')
-        assert sources._source_failures['rss'] == 0
+        assert sources._state.source_failures['rss'] == 0
 
     def test_backoff_capped(self, monkeypatch):
         monkeypatch.setattr(sources, 'SOURCE_COOLDOWN_MAX', 1000)
         import time
         for _ in range(10):
             sources._mark_source_down('rss')
-        assert sources._source_cooldown_until['rss'] - time.time() <= 1000
+        assert sources._state.source_cooldown_until['rss'] - time.time() <= 1000
 
     def test_explicit_seconds_does_not_increment_failures(self):
         sources._mark_source_down('rss', 50)
-        assert sources._source_failures.get('rss', 0) == 0
+        assert sources._state.source_failures.get('rss', 0) == 0
 
 
 class TestProxying:
@@ -325,7 +315,7 @@ class TestProxying:
         monkeypatch.setattr(sources.requests, 'get', fake_get)
         posts = sources.fetch_posts_rss('gamedeals')
         assert attempts == ['http://dead:8000', 'http://good:8000']
-        assert 'http://dead:8000' in sources._proxy_cooldown_until   # cooled down
+        assert 'http://dead:8000' in sources._state.proxy_cooldown_until   # cooled down
         assert posts is not None
 
     def test_all_proxies_down_raises_no_direct_leak(self, monkeypatch):

--- a/tests/test_thread_comments.py
+++ b/tests/test_thread_comments.py
@@ -1,4 +1,5 @@
 """Tests for thread comment monitoring functionality."""
+
 from unittest.mock import MagicMock
 
 import responses
@@ -7,13 +8,16 @@ import responses
 def make_comment_response(comments):
     """Build a Reddit-style JSON response for a thread with given comments."""
     children = [
-        {'kind': 't1', 'data': {
-            'id': c['id'],
-            'body': c['body'],
-            'author': c.get('author', 'testuser'),
-            'score': c.get('score', 1),
-            'permalink': c.get('permalink', f"/r/test/comments/thread/{c['id']}/"),
-        }}
+        {
+            'kind': 't1',
+            'data': {
+                'id': c['id'],
+                'body': c['body'],
+                'author': c.get('author', 'testuser'),
+                'score': c.get('score', 1),
+                'permalink': c.get('permalink', f"/r/test/comments/thread/{c['id']}/"),
+            },
+        }
         for c in comments
     ]
     return [
@@ -23,7 +27,6 @@ def make_comment_response(comments):
 
 
 class TestFetchThreadCommentsJson:
-
     @responses.activate
     def test_returns_top_level_comments(self):
         from bot import fetch_thread_comments_json
@@ -31,10 +34,12 @@ class TestFetchThreadCommentsJson:
         responses.add(
             responses.GET,
             'https://old.reddit.com/r/frugalmalefashion/comments/abc123.json',
-            json=make_comment_response([
-                {'id': 'c1', 'body': 'Size XS shirt $20', 'author': 'seller1'},
-                {'id': 'c2', 'body': 'Size L pants $30', 'author': 'seller2'},
-            ]),
+            json=make_comment_response(
+                [
+                    {'id': 'c1', 'body': 'Size XS shirt $20', 'author': 'seller1'},
+                    {'id': 'c2', 'body': 'Size L pants $30', 'author': 'seller2'},
+                ]
+            ),
             status=200,
         )
 
@@ -106,10 +111,11 @@ class TestFetchThreadCommentsJson:
 
 
 class TestProcessComment:
-
-    def _make_monitor(self, keywords, keyword_logic='any', exclude_keywords=None,
-                      author_includes=None, author_excludes=None):
+    def _make_monitor(
+        self, keywords, keyword_logic='any', exclude_keywords=None, author_includes=None, author_excludes=None
+    ):
         from bot import RedditMonitor
+
         monitor = RedditMonitor.__new__(RedditMonitor)
         monitor.subreddit = 'frugalmalefashion'
         monitor.keywords = keywords
@@ -179,7 +185,6 @@ class TestProcessComment:
 
 
 class TestFindCurrentThread:
-
     @responses.activate
     def test_finds_thread_by_title_pattern_via_json(self):
         from bot import RedditMonitor
@@ -191,20 +196,36 @@ class TestFindCurrentThread:
         responses.add(
             responses.GET,
             'https://old.reddit.com/r/frugalmalefashion/new.json',
-            json={'data': {'children': [
-                {'data': {
-                    'id': 'thread1',
-                    'title': 'Official Weekly Buy/Sell/Trade Thread',
-                    'permalink': '/r/frugalmalefashion/comments/thread1/official_weekly/',
-                    'url': '', 'score': 1, 'domain': '', 'link_flair_text': '', 'author': 'mod',
-                }},
-                {'data': {
-                    'id': 'post2',
-                    'title': 'Cool jacket deal',
-                    'permalink': '/r/frugalmalefashion/comments/post2/cool_jacket/',
-                    'url': '', 'score': 5, 'domain': '', 'link_flair_text': '', 'author': 'user',
-                }},
-            ]}},
+            json={
+                'data': {
+                    'children': [
+                        {
+                            'data': {
+                                'id': 'thread1',
+                                'title': 'Official Weekly Buy/Sell/Trade Thread',
+                                'permalink': '/r/frugalmalefashion/comments/thread1/official_weekly/',
+                                'url': '',
+                                'score': 1,
+                                'domain': '',
+                                'link_flair_text': '',
+                                'author': 'mod',
+                            }
+                        },
+                        {
+                            'data': {
+                                'id': 'post2',
+                                'title': 'Cool jacket deal',
+                                'permalink': '/r/frugalmalefashion/comments/post2/cool_jacket/',
+                                'url': '',
+                                'score': 5,
+                                'domain': '',
+                                'link_flair_text': '',
+                                'author': 'user',
+                            }
+                        },
+                    ]
+                }
+            },
             status=200,
         )
 

--- a/tests/test_thread_comments.py
+++ b/tests/test_thread_comments.py
@@ -1,8 +1,7 @@
 """Tests for thread comment monitoring functionality."""
-import pytest
+from unittest.mock import MagicMock
+
 import responses
-import json
-from unittest.mock import MagicMock, patch, PropertyMock
 
 
 def make_comment_response(comments):
@@ -240,8 +239,9 @@ class TestFindCurrentThread:
         assert thread_id is None
 
     def test_uses_cache_within_ttl(self):
-        from bot import RedditMonitor
         import time
+
+        from bot import RedditMonitor
 
         RedditMonitor._thread_cache = {
             'frugalmalefashion-Buy/Sell/Trade': {


### PR DESCRIPTION
Follow-up to #143, which merged early and only captured the first two commits. This brings the remaining 10 commits on the branch to `master`.

## Notable — a real fix that's currently missing from master
- **`fix: hot-reload credentials`** — without it, a Sylvia key (or Reddit creds) entered in the UI after the bot started is written to `credentials.json` but never picked up, so fetches silently fall back to RSS until a restart. The bot now watches `credentials.json`'s mtime and reloads live.

## Features / fixes
- **Data-source picker** in Settings (Reddit vs Sylvia dropdown) that also sets the bot's source order (`GET/PUT /api/source-order`), applied live.
- **Rich filters credited to Sylvia** — score/domain filters no longer hidden when running on the Sylvia gateway (it returns full post data).
- Docs for the Sylvia source, proxy/IP-hiding env vars, and the source picker; fixed stale `oauth -> rss -> json` comments.

## Codebase cleanup
- **A** — de-duplicated credential validation/masking helpers.
- **B** — split the 404-line `SettingsModal` into focused subcomponents.
- **C** — encapsulated `sources.py`'s ~15 runtime globals in a `_SourceState` class behind a function facade.
- api.py source lists now reference `config` instead of hardcoded copies.
- **ruff** added (config + `requirements-test`), lint fixed, whole codebase formatted.
- **CLAUDE.md** documenting the coding principles.

## Testing
- 99 Python tests pass; `ruff check` + `ruff format --check` clean; frontend tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)