### PR TITLE
Fix: Sylvia wrongly shown as fallback; unify "rich source" definition

### DIFF
--- a/api.py
+++ b/api.py
@@ -62,17 +62,19 @@ def get_source_capability():
     creds = load_credentials()
     client_id = creds.get('reddit_client_id') or os.getenv('REDDIT_CLIENT_ID')
     client_secret = creds.get('reddit_client_secret') or os.getenv('REDDIT_CLIENT_SECRET')
+    sylvia_key = creds.get('sylvia_api_key') or os.getenv('SYLVIA_API_KEY')
+
     oauth_available = bool(client_id and client_secret) and 'oauth' in order
 
-    sylvia_key = creds.get('sylvia_api_key') or os.getenv('SYLVIA_API_KEY')
-    sylvia_available = bool(sylvia_key) and 'sylvia' in order
+    # Score/domain filters need a rich source (config.RICH_SOURCES) that's both in the order
+    # AND configured. Derives from the same constant the bot and UI use, so they can't drift.
+    rich_configured = {'oauth': bool(client_id and client_secret), 'sylvia': bool(sylvia_key)}
+    rich_filters_supported = any(s in order and rich_configured.get(s, False) for s in rs_config.RICH_SOURCES)
 
     return {
         'source_order': order,
         'oauth_available': oauth_available,
-        # score/domain need a full-data source: the authenticated API or the Sylvia
-        # gateway both expose them; RSS does not (so filters can't be applied there).
-        'rich_filters_supported': oauth_available or sylvia_available,
+        'rich_filters_supported': rich_filters_supported,
     }
 
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -19,6 +19,9 @@ export default function Home() {
   const [isConfigured, setIsConfigured] = useState<boolean | null>(null);
   const [fallbackWarning, setFallbackWarning] = useState<string | null>(null);
   const [activeSource, setActiveSource] = useState<string | null>(null);
+  // Whether the *currently active* source is a degradation (no score/domain). Comes from the
+  // backend (config.RICH_SOURCES), so the UI never hardcodes which sources are "rich".
+  const [activeSourceDegraded, setActiveSourceDegraded] = useState(false);
   const [richFiltersSupported, setRichFiltersSupported] = useState(true);
 
   const checkCredentials = async () => {
@@ -38,11 +41,9 @@ export default function Home() {
       const data = await response.json();
       setActiveSource(data.active_source ?? null);
       setRichFiltersSupported(data.rich_filters_supported !== false);
-      if (data.using_json_fallback && data.message) {
-        setFallbackWarning(data.message);
-      } else {
-        setFallbackWarning(null);
-      }
+      const degraded = !!data.using_json_fallback;
+      setActiveSourceDegraded(degraded);
+      setFallbackWarning(degraded && data.message ? data.message : null);
     } catch (err) {
       // Ignore status check errors
     }
@@ -197,11 +198,9 @@ export default function Home() {
             <div className="text-sm">
               <p className="font-semibold text-amber-200">API Fallback Mode Active</p>
               <p className="text-amber-100/80 mt-1">{fallbackWarning}</p>
-              {(activeSource === 'rss' || activeSource === 'json') && (
-                <p className="text-amber-100/60 mt-1">
-                  Score and domain filters are unavailable on this source and won&apos;t be applied.
-                </p>
-              )}
+              <p className="text-amber-100/60 mt-1">
+                Score and domain filters are unavailable on this source and won&apos;t be applied.
+              </p>
             </div>
           </div>
         </div>
@@ -213,7 +212,7 @@ export default function Home() {
           <div className="max-w-lg mx-auto px-4 py-3 flex items-center justify-between gap-3">
             <div className="flex items-center gap-2 text-yellow-200 text-sm">
               <span>⚠️</span>
-              <span>Bot won't work without credentials configured</span>
+              <span>Bot won&apos;t work without credentials configured</span>
             </div>
             <button
               onClick={() => setIsSettingsOpen(true)}
@@ -284,6 +283,7 @@ export default function Home() {
           onDelete={handleDelete}
           richFiltersSupported={richFiltersSupported}
           activeSource={activeSource}
+          activeSourceDegraded={activeSourceDegraded}
         />
       )}
 

--- a/frontend/components/MonitorModal.tsx
+++ b/frontend/components/MonitorModal.tsx
@@ -22,6 +22,9 @@ interface MonitorModalProps {
     // filters (which RSS/JSON can't provide) are hidden.
     richFiltersSupported?: boolean;
     activeSource?: string | null;
+    // True when the currently active source is a degradation (no score/domain). Backend-driven
+    // (config.RICH_SOURCES) so we don't hardcode which sources are degraded.
+    activeSourceDegraded?: boolean;
 }
 
 type TabType = 'filters' | 'alerts' | 'settings';
@@ -34,6 +37,7 @@ export default function MonitorModal({
     onDelete,
     richFiltersSupported = true,
     activeSource = null,
+    activeSourceDegraded = false,
 }: MonitorModalProps) {
     const [activeTab, setActiveTab] = useState<TabType>('filters');
     const [formData, setFormData] = useState<Partial<Monitor>>(DEFAULT_MONITOR);
@@ -446,7 +450,7 @@ export default function MonitorModal({
 
                                     {richFiltersSupported && (
                                     <>
-                                    {(activeSource === 'rss' || activeSource === 'json') && (
+                                    {activeSourceDegraded && (
                                         <div className="text-xs text-amber-300/80 bg-amber-500/10 border border-amber-500/20 rounded-md px-3 py-2">
                                             Currently fetching via <span className="font-semibold uppercase">{activeSource}</span>. Score and domain filters are paused until the Reddit API recovers.
                                         </div>

--- a/reddit_scraper/config.py
+++ b/reddit_scraper/config.py
@@ -42,6 +42,20 @@ OPTIONAL_LIST_FIELDS = [
 VALID_SOURCES = ('oauth', 'rss', 'json', 'sylvia')
 DEFAULT_SOURCE_ORDER = ['oauth', 'json', 'rss']
 
+# The single source of truth for "does this source provide score/domain data and count as a
+# healthy primary (not a degradation)?" Everything that needs that distinction derives from
+# here: the bot's fallback flag (sources._SourceState.set_active_source), the API's
+# rich_filters_supported (api.get_source_capability), and the UI banner/filter gating. Add a
+# new rich source here and all three stay in agreement. `json` returns score/domain too but
+# is an unofficial, frequently-blocked fallback, so it is deliberately not counted rich.
+RICH_SOURCES = ('oauth', 'sylvia')
+
+
+def supports_rich_filters(source):
+    """True if `source` provides score/domain (so upvote/domain filters apply and it's not
+    a degraded fallback for UI purposes). See RICH_SOURCES."""
+    return source in RICH_SOURCES
+
 
 # --- Paths (call-time, env-aware) ---
 def get_data_dir():

--- a/reddit_scraper/sources.py
+++ b/reddit_scraper/sources.py
@@ -113,7 +113,10 @@ class _SourceState:
         if source != self.active_source:
             self.active_source = source
             logging.info(f"📡 Active Reddit data source: {source}")
-            status.save_bot_status(source != 'oauth', f"Active data source: {source}", active_source=source)
+            # "Fallback" = a degraded source (no score/domain), not merely "not oauth" — so
+            # the Sylvia gateway isn't wrongly flagged as a fallback. See config.RICH_SOURCES.
+            using_fallback = not config.supports_rich_filters(source)
+            status.save_bot_status(using_fallback, f"Active data source: {source}", active_source=source)
 
     # --- one-time OAuth-failure notification guard ---
     def claim_auth_error_notification(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,17 @@ def reset_order():
     config.set_source_order(None)
 
 
+class TestRichSources:
+    def test_oauth_and_sylvia_are_rich(self):
+        assert config.supports_rich_filters('oauth')
+        assert config.supports_rich_filters('sylvia')
+
+    def test_rss_and_json_are_not_rich(self):
+        assert not config.supports_rich_filters('rss')
+        assert not config.supports_rich_filters('json')
+        assert not config.supports_rich_filters(None)
+
+
 class TestSourceOrder:
     def test_default_when_unset(self):
         config.set_source_order(None)

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -273,6 +273,38 @@ class TestBackoff:
         assert sources._state.source_failures.get('rss', 0) == 0
 
 
+class TestActiveSourceFallbackFlag:
+    """The bot_status 'using_fallback' flag must track config.RICH_SOURCES, so the Sylvia
+    gateway isn't mislabeled as a degraded fallback in the UI."""
+
+    def _capture(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            sources.status, 'save_bot_status', lambda using_fallback, *a, **k: calls.append(using_fallback)
+        )
+        return calls
+
+    def test_sylvia_is_not_fallback(self, monkeypatch):
+        calls = self._capture(monkeypatch)
+        sources._set_active_source('sylvia')
+        assert calls == [False]
+
+    def test_oauth_is_not_fallback(self, monkeypatch):
+        calls = self._capture(monkeypatch)
+        sources._set_active_source('oauth')
+        assert calls == [False]
+
+    def test_rss_is_fallback(self, monkeypatch):
+        calls = self._capture(monkeypatch)
+        sources._set_active_source('rss')
+        assert calls == [True]
+
+    def test_json_is_fallback(self, monkeypatch):
+        calls = self._capture(monkeypatch)
+        sources._set_active_source('json')
+        assert calls == [True]
+
+
 class TestProxying:
     def _record_get(self, monkeypatch):
         """Replace requests.get with a recorder returning a trivial 200 response."""


### PR DESCRIPTION
## Problem
Running on the Sylvia gateway showed a bogus **"API Fallback Mode Active"** banner (and "score/domain filters unavailable"), even though Sylvia returns full post data. Root cause: the "is this source a degradation?" decision lived in **three places that disagreed** —
- `sources.py`: `source != 'oauth'` → flagged Sylvia as fallback
- `api.py`: `oauth or sylvia` = rich
- frontend: hardcoded `activeSource in ('rss','json')`, in two files

## Fix — one source of truth
`config.RICH_SOURCES` (`('oauth','sylvia')`) + `supports_rich_filters()`. All three derive from it, so they can't drift:
- bot's `using_fallback` flag
- API's `rich_filters_supported`
- frontend banner + monitor note (via the backend `using_json_fallback` flag / new `activeSourceDegraded` prop — no more hardcoded source names)

Add a new rich source in one place and everything agrees.

## Also
- Fixed a pre-existing unescaped-apostrophe eslint **error** in `page.tsx`.

## Note on what you saw
The bot was on Sylvia the whole time (logs confirm). The banner also read `rss` because the page fetches `/api/status` once on mount and wasn't refreshed after the source switched — a refresh would have updated it. This change removes the wrong banner entirely when on Sylvia.

## Testing
105 Python tests pass; ruff + frontend tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)