### PR TITLE
Reduce cross-layer coupling + document the single-source-of-truth principle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,31 @@ Frontend: `npm run lint` / `npm run build` in `frontend/`.
 - **Centralize shared access** — paths/config through `config.py`, credentials through
   `credentials.py`. Don't re-read env vars or files that a helper already owns.
 
+### Single source of truth (avoid cross-layer coupling)
+
+The bot, the API, and the frontend must not each encode the same domain knowledge — when they
+drift, you get bugs like "Sylvia shown as a fallback." Rules, in priority order:
+
+1. **Define a decision once, in `config.py`, and derive everywhere.** Source topology lives
+   there and nowhere else: `VALID_SOURCES`, `DEFAULT_SOURCE_ORDER`, `RICH_SOURCES` /
+   `supports_rich_filters()`, `SOURCE_ORDER_PRESETS`. The bot, `api.py`, and tests all import
+   these — adding a source in one place keeps them in agreement. Don't hardcode a parallel
+   copy (the earlier `api.py` `('oauth','rss','json')` list is the anti-pattern).
+2. **The backend owns business decisions; the frontend consumes API values — it never
+   re-derives them.** The UI reads flags like `rich_filters_supported` and
+   `using_json_fallback` from `/api/status` and renders them. It must **not** re-compute a
+   decision from raw fields (e.g. `activeSource in ('rss','json')` is banned — that logic
+   belongs in the backend, keyed off `RICH_SOURCES`).
+3. **Constants that genuinely must be mirrored across Python↔TypeScript** (no shared schema,
+   and codegen would be overkill here) — e.g. the monitor color palette (`DEFAULT_COLORS` in
+   `config.py` ↔ `frontend/types/monitor.ts`) and monitor field defaults (`clean_monitor` ↔
+   `DEFAULT_MONITOR`) — are the **only** acceptable duplication. Each copy must carry a
+   `MUST stay in sync with <path>` comment, and you change both together.
+
+Rule of thumb: if changing a rule means editing more than one file *and* those files can't see
+each other's value, you've coupled them — hoist the value into `config.py` (backend) or expose
+it through the API (frontend).
+
 ### Error handling
 
 - **Fetchers signal blocking by raising, transient/empty by returning `None`.** RSS/JSON/Sylvia

--- a/api.py
+++ b/api.py
@@ -505,15 +505,6 @@ def update_credentials():
         return jsonify({'error': str(e)}), 500
 
 
-# Which data source the UI dropdown selects, mapped to the bot's source order.
-# The free json/rss pathways are kept as a last-ditch fallback behind the chosen
-# primary so a blocked primary still degrades gracefully rather than going dark.
-SOURCE_PRESETS = {
-    'reddit': ['oauth', 'json', 'rss'],
-    'sylvia': ['sylvia', 'json', 'rss'],
-}
-
-
 @app.route('/api/source-order', methods=['GET'])
 def get_source_order():
     """Report the active data source (derived from the primary of the saved source order)."""
@@ -533,13 +524,14 @@ def update_source_order():
     try:
         data = request.get_json() or {}
         active = data.get('active_source')
-        if active not in SOURCE_PRESETS:
-            return jsonify({'error': f"active_source must be one of {list(SOURCE_PRESETS)}"}), 400
+        presets = rs_config.SOURCE_ORDER_PRESETS
+        if active not in presets:
+            return jsonify({'error': f"active_source must be one of {list(presets)}"}), 400
 
         config = load_config() or {}
-        config['source_order'] = SOURCE_PRESETS[active]
+        config['source_order'] = presets[active]
         save_config(config)
-        return jsonify({'success': True, 'active_source': active, 'source_order': SOURCE_PRESETS[active]})
+        return jsonify({'success': True, 'active_source': active, 'source_order': presets[active]})
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 

--- a/frontend/types/monitor.ts
+++ b/frontend/types/monitor.ts
@@ -17,6 +17,8 @@ export interface Monitor {
     author_excludes: string[];
 }
 
+// MUST stay in sync with DEFAULT_COLORS in reddit_scraper/config.py (backend auto-assigns
+// from that list on create; this is the picker) — keep the two lists identical.
 export const DEFAULT_COLORS = [
     '#8B5CF6', // Purple
     '#3B82F6', // Blue

--- a/reddit_scraper/config.py
+++ b/reddit_scraper/config.py
@@ -9,15 +9,19 @@ import logging
 import os
 import uuid
 
+# Monitor color palette (used to auto-assign a color on create). MUST stay in sync with the
+# frontend picker in frontend/types/monitor.ts — keep the two lists identical.
 DEFAULT_COLORS = [
-    '#8B5CF6',
-    '#3B82F6',
-    '#22C55E',
-    '#EF4444',
-    '#F97316',
-    '#EC4899',
-    '#06B6D4',
-    '#EAB308',
+    '#8B5CF6',  # Purple
+    '#3B82F6',  # Blue
+    '#22C55E',  # Green
+    '#EF4444',  # Red
+    '#F97316',  # Orange
+    '#EC4899',  # Pink
+    '#06B6D4',  # Cyan
+    '#EAB308',  # Yellow
+    '#10B981',  # Emerald
+    '#F43F5E',  # Rose
 ]
 
 OPTIONAL_LIST_FIELDS = [
@@ -55,6 +59,15 @@ def supports_rich_filters(source):
     """True if `source` provides score/domain (so upvote/domain filters apply and it's not
     a degraded fallback for UI purposes). See RICH_SOURCES."""
     return source in RICH_SOURCES
+
+
+# The UI's data-source picker maps a chosen primary to a full source order. The free json/rss
+# pathways stay as a last-ditch fallback behind the primary so a blocked primary degrades
+# gracefully. Lives here (not in api.py) so all source-topology knowledge is in one module.
+SOURCE_ORDER_PRESETS = {
+    'reddit': ['oauth', 'json', 'rss'],
+    'sylvia': ['sylvia', 'json', 'rss'],
+}
 
 
 # --- Paths (call-time, env-aware) ---


### PR DESCRIPTION
Follow-up to the Sylvia-fallback bug, which was a symptom of a general problem: the same domain knowledge encoded in the bot, the API, and the frontend, drifting apart.

## Concrete fixes
- **`SOURCE_ORDER_PRESETS` moved** api.py → `config.py`, so all source-topology knowledge (`VALID_SOURCES`, `DEFAULT_SOURCE_ORDER`, `RICH_SOURCES`, presets) lives in one module.
- **`DEFAULT_COLORS` had already drifted** — backend had 8 colors, the frontend picker 10. Synced, with a `MUST stay in sync with <path>` cross-reference on both sides.

## The principle (now in CLAUDE.md)
1. Define a decision **once in `config.py`**, derive everywhere.
2. **Backend owns business decisions; the frontend consumes API flags** (`rich_filters_supported`, `using_json_fallback`) and never re-derives them (`activeSource in ('rss','json')` is banned).
3. Only **static presentational constants** may be mirrored across Python↔TS, and must be cross-referenced.

## Testing
105 tests pass; ruff + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)