### PR TITLE
Codegen phase 2: backend monitor handling through the Pydantic model

### DIFF
--- a/api.py
+++ b/api.py
@@ -16,6 +16,7 @@ from flask_cors import CORS
 
 from reddit_scraper import config as rs_config
 from reddit_scraper import credentials as rs_credentials
+from reddit_scraper import models
 
 app = Flask(__name__)
 CORS(app)  # Enable CORS for all routes
@@ -26,8 +27,8 @@ CONFIG_FILE_PATH = rs_config.get_config_path()
 BOT_STATUS_FILE_PATH = rs_config.get_bot_status_path()
 
 DEFAULT_COLORS = rs_config.DEFAULT_COLORS
-OPTIONAL_LIST_FIELDS = rs_config.OPTIONAL_LIST_FIELDS
-clean_monitor = rs_config.clean_monitor
+# Fields a client may set on a monitor (everything the model owns except the server-managed id).
+MONITOR_INPUT_FIELDS = tuple(f for f in models.Monitor.model_fields if f != 'id')
 
 
 def load_config():
@@ -189,26 +190,12 @@ def create_monitor():
         config = load_config()
         monitors = config.get('subreddits_to_search', [])
 
-        # Create new monitor with defaults
-        new_monitor = {
-            'id': str(uuid.uuid4()),
-            'name': data.get('name', f"r/{data['subreddit']}"),
-            'subreddit': data['subreddit'].strip().lower().replace('r/', ''),
-            'keywords': data.get('keywords', []),
-            'exclude_keywords': data.get('exclude_keywords', []),
-            'min_upvotes': data.get('min_upvotes'),
-            'color': data.get('color', DEFAULT_COLORS[len(monitors) % len(DEFAULT_COLORS)]),
-            'enabled': data.get('enabled', True),
-            'cooldown_minutes': data.get('cooldown_minutes', 10),
-            'max_post_age_hours': data.get('max_post_age_hours', 12),
-            'domain_contains': data.get('domain_contains', []),
-            'domain_excludes': data.get('domain_excludes', []),
-            'flair_contains': data.get('flair_contains', []),
-            'author_includes': data.get('author_includes', []),
-            'author_excludes': data.get('author_excludes', []),
-        }
+        # Validate + default through the model (which normalizes subreddit, fills name, etc.).
+        payload = {field: data[field] for field in MONITOR_INPUT_FIELDS if field in data}
+        payload['id'] = str(uuid.uuid4())
+        payload.setdefault('color', DEFAULT_COLORS[len(monitors) % len(DEFAULT_COLORS)])
+        new_monitor = models.Monitor(**payload).to_stored_dict()
 
-        clean_monitor(new_monitor)
         monitors.append(new_monitor)
         config['subreddits_to_search'] = monitors
         save_config(config)
@@ -248,38 +235,14 @@ def update_monitor(monitor_id):
 
         for i, monitor in enumerate(monitors):
             if monitor.get('id') == monitor_id:
-                # Update fields
-                if 'name' in data:
-                    monitors[i]['name'] = data['name']
-                if 'subreddit' in data:
-                    monitors[i]['subreddit'] = data['subreddit'].strip().lower().replace('r/', '')
-                if 'keywords' in data:
-                    monitors[i]['keywords'] = data['keywords']
-                if 'exclude_keywords' in data:
-                    monitors[i]['exclude_keywords'] = data['exclude_keywords']
-                if 'min_upvotes' in data:
-                    monitors[i]['min_upvotes'] = data['min_upvotes']
-                if 'color' in data:
-                    monitors[i]['color'] = data['color']
-                if 'enabled' in data:
-                    monitors[i]['enabled'] = data['enabled']
-                if 'cooldown_minutes' in data:
-                    monitors[i]['cooldown_minutes'] = data['cooldown_minutes']
-                if 'max_post_age_hours' in data:
-                    monitors[i]['max_post_age_hours'] = data['max_post_age_hours']
-                # New filter fields
-                if 'domain_contains' in data:
-                    monitors[i]['domain_contains'] = data['domain_contains']
-                if 'domain_excludes' in data:
-                    monitors[i]['domain_excludes'] = data['domain_excludes']
-                if 'flair_contains' in data:
-                    monitors[i]['flair_contains'] = data['flair_contains']
-                if 'author_includes' in data:
-                    monitors[i]['author_includes'] = data['author_includes']
-                if 'author_excludes' in data:
-                    monitors[i]['author_excludes'] = data['author_excludes']
+                # Merge the client-settable fields onto the existing monitor, then re-validate
+                # + re-serialize through the model (preserving id and any bot-only fields).
+                merged = dict(monitor)
+                for field in MONITOR_INPUT_FIELDS:
+                    if field in data:
+                        merged[field] = data[field]
+                monitors[i] = models.Monitor(**merged).to_stored_dict()
 
-                clean_monitor(monitors[i])
                 config['subreddits_to_search'] = monitors
                 save_config(config)
 

--- a/frontend/types/generated.ts
+++ b/frontend/types/generated.ts
@@ -4,21 +4,19 @@
 /**
  * A monitor as persisted in search.json ('subreddits_to_search' entries).
  *
- * Fields with defaults are optional on create (the API/config supplies them); id, name,
- * subreddit, and color are always present on a stored monitor.
+ * Defaults live here. `extra='allow'` preserves any bot-only or legacy fields (e.g.
+ * monitor_type / thread_title_pattern / keyword_logic on hand-configured thread monitors)
+ * so routing an existing monitor through the model never drops data.
  */
 export interface Monitor {
   id: string;
-  name: string;
+  name?: string;
   subreddit: string;
   color: string;
   enabled?: boolean;
   cooldown_minutes?: number;
   max_post_age_hours?: number;
   min_upvotes?: number | null;
-  keyword_logic?: string;
-  monitor_type?: string;
-  thread_title_pattern?: string;
   keywords?: string[];
   exclude_keywords?: string[];
   domain_contains?: string[];
@@ -26,4 +24,5 @@ export interface Monitor {
   flair_contains?: string[];
   author_includes?: string[];
   author_excludes?: string[];
+  [k: string]: unknown;
 }

--- a/reddit_scraper/config.py
+++ b/reddit_scraper/config.py
@@ -9,6 +9,8 @@ import logging
 import os
 import uuid
 
+from . import models
+
 # Monitor color palette (used to auto-assign a color on create). MUST stay in sync with the
 # frontend picker in frontend/types/monitor.ts — keep the two lists identical.
 DEFAULT_COLORS = [
@@ -22,15 +24,6 @@ DEFAULT_COLORS = [
     '#EAB308',  # Yellow
     '#10B981',  # Emerald
     '#F43F5E',  # Rose
-]
-
-OPTIONAL_LIST_FIELDS = [
-    'exclude_keywords',
-    'domain_contains',
-    'domain_excludes',
-    'flair_contains',
-    'author_includes',
-    'author_excludes',
 ]
 
 # Data-source pathways, tried in order by the dispatcher:
@@ -126,48 +119,33 @@ def save_config(config):
         json.dump(config, f, indent=4)
 
 
-def clean_monitor(monitor):
-    """Strip optional fields that are empty/null to keep search.json tidy."""
-    for field in OPTIONAL_LIST_FIELDS:
-        if field in monitor and not monitor[field]:
-            del monitor[field]
-    if 'min_upvotes' in monitor and monitor['min_upvotes'] is None:
-        del monitor['min_upvotes']
-    return monitor
+def normalize_monitor(monitor, index=0):
+    """Return a monitor dict normalized through the Monitor model: missing id/name/color and
+    other defaults filled in, tidy on-disk shape. Bot-only/legacy fields are preserved. A
+    monitor that can't be validated (e.g. no subreddit) is returned unchanged."""
+    try:
+        seeded = {
+            'id': monitor.get('id') or str(uuid.uuid4()),
+            'color': monitor.get('color') or DEFAULT_COLORS[index % len(DEFAULT_COLORS)],
+            **monitor,
+        }
+        return models.Monitor(**seeded).to_stored_dict()
+    except Exception:
+        return monitor
 
 
 def load_managed_config():
-    """Normalizing read used by the API: ensures ids/fields, creates a default
-    file when missing, and persists any fields it had to add."""
+    """Normalizing read used by the API: fills in ids/defaults via the Monitor model, creates
+    a default file when missing, and persists any normalization it had to apply."""
     path = get_config_path()
     try:
         with open(path, 'r') as f:
             config = json.load(f)
 
         monitors = config.get('subreddits_to_search', [])
-        updated = False
-        for i, monitor in enumerate(monitors):
-            if 'id' not in monitor:
-                monitor['id'] = str(uuid.uuid4())
-                updated = True
-            if 'name' not in monitor:
-                monitor['name'] = f"r/{monitor.get('subreddit', 'unknown')}"
-                updated = True
-            if 'color' not in monitor:
-                monitor['color'] = DEFAULT_COLORS[i % len(DEFAULT_COLORS)]
-                updated = True
-            if 'enabled' not in monitor:
-                monitor['enabled'] = True
-                updated = True
-            if 'cooldown_minutes' not in monitor:
-                monitor['cooldown_minutes'] = 10
-                updated = True
-            if 'max_post_age_hours' not in monitor:
-                monitor['max_post_age_hours'] = 12
-                updated = True
-
-        if updated:
-            config['subreddits_to_search'] = monitors
+        normalized = [normalize_monitor(m, i) for i, m in enumerate(monitors)]
+        if normalized != monitors:
+            config['subreddits_to_search'] = normalized
             save_config(config)
         return config
     except FileNotFoundError:

--- a/reddit_scraper/models.py
+++ b/reddit_scraper/models.py
@@ -1,34 +1,45 @@
 """Pydantic models — the single schema-of-record for data shared across the stack.
 
 The frontend's TypeScript types are generated from these models (see scripts/gen_types.py),
-so a field renamed/added/removed here flows to the UI instead of drifting. See CLAUDE.md
-("Single source of truth"). Backend validation/serialization against these models is being
-adopted incrementally.
+so a field renamed/added/removed here flows to the UI instead of drifting. The backend also
+validates/serializes monitors through `Monitor` (create/update/normalize all go through it),
+so field defaults and the tidy on-disk shape live here and nowhere else. See CLAUDE.md
+("Single source of truth").
 """
 
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+# Optional list fields dropped from the stored form when empty (keeps search.json tidy).
+OPTIONAL_LIST_FIELDS = (
+    'exclude_keywords',
+    'domain_contains',
+    'domain_excludes',
+    'flair_contains',
+    'author_includes',
+    'author_excludes',
+)
 
 
 class Monitor(BaseModel):
     """A monitor as persisted in search.json ('subreddits_to_search' entries).
 
-    Fields with defaults are optional on create (the API/config supplies them); id, name,
-    subreddit, and color are always present on a stored monitor.
+    Defaults live here. `extra='allow'` preserves any bot-only or legacy fields (e.g.
+    monitor_type / thread_title_pattern / keyword_logic on hand-configured thread monitors)
+    so routing an existing monitor through the model never drops data.
     """
 
+    model_config = ConfigDict(extra='allow')
+
     id: str
-    name: str
+    name: str = ''
     subreddit: str
     color: str
     enabled: bool = True
     cooldown_minutes: int = 10
     max_post_age_hours: int = 12
     min_upvotes: Optional[int] = None
-    keyword_logic: str = 'any'
-    monitor_type: str = 'posts'
-    thread_title_pattern: str = 'Buy/Sell/Trade'
     keywords: list[str] = Field(default_factory=list)
     exclude_keywords: list[str] = Field(default_factory=list)
     domain_contains: list[str] = Field(default_factory=list)
@@ -36,3 +47,25 @@ class Monitor(BaseModel):
     flair_contains: list[str] = Field(default_factory=list)
     author_includes: list[str] = Field(default_factory=list)
     author_excludes: list[str] = Field(default_factory=list)
+
+    @field_validator('subreddit')
+    @classmethod
+    def _normalize_subreddit(cls, v: str) -> str:
+        return v.strip().lower().replace('r/', '')
+
+    @model_validator(mode='after')
+    def _default_name(self):
+        if not self.name:
+            self.name = f'r/{self.subreddit}'
+        return self
+
+    def to_stored_dict(self) -> dict:
+        """Dict for search.json: drops empty optional lists and a null min_upvotes to keep the
+        file tidy (matches the old config.clean_monitor). Bot-only/legacy fields pass through."""
+        data = self.model_dump()
+        for field in OPTIONAL_LIST_FIELDS:
+            if not data.get(field):
+                data.pop(field, None)
+        if data.get('min_upvotes') is None:
+            data.pop('min_upvotes', None)
+        return data

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,9 +14,21 @@ class TestMonitorModel:
         assert m.cooldown_minutes == 10
         assert m.max_post_age_hours == 12
         assert m.min_upvotes is None
-        assert m.keyword_logic == 'any'
-        assert m.monitor_type == 'posts'
         assert m.keywords == [] and m.domain_contains == []
+
+    def test_normalizes_subreddit_and_defaults_name(self):
+        m = models.Monitor(id='1', subreddit='R/GameDeals', color='#fff')
+        assert m.subreddit == 'gamedeals'  # stripped/lowercased, r/ removed
+        assert m.name == 'r/gamedeals'  # name defaults from subreddit
+
+    def test_preserves_bot_only_fields(self):
+        m = models.Monitor(id='1', subreddit='x', color='#fff', monitor_type='thread_comments')
+        assert m.to_stored_dict()['monitor_type'] == 'thread_comments'  # extra='allow' passthrough
+
+    def test_to_stored_dict_strips_empties(self):
+        stored = models.Monitor(id='1', subreddit='x', color='#fff').to_stored_dict()
+        assert 'exclude_keywords' not in stored and 'min_upvotes' not in stored
+        assert stored['keywords'] == []  # keywords is always kept
 
     def test_round_trips_a_full_monitor(self):
         data = {


### PR DESCRIPTION
Phase 2 of the Pydantic → TS work (follows #147). The backend now **validates and serializes monitors through `models.Monitor`**, so monitor defaults and the on-disk shape live in one place instead of being duplicated across `create_monitor`, `update_monitor`, and `config.clean_monitor` / `load_managed_config`.

## Changes
- **`models.Monitor`** gains: field defaults, a subreddit normalizer (`R/GameDeals` → `gamedeals`), a name default (`r/<sub>`), and `to_stored_dict()` (drops empty optional lists + null `min_upvotes`, matching the old `clean_monitor`). `extra='allow'` **preserves bot-only/legacy fields** (`monitor_type`, `thread_title_pattern`, `keyword_logic`) so a round-trip never drops data.
- **`api.py`**: create/update route through the model; `MONITOR_INPUT_FIELDS` is derived from the model (no hardcoded field list); removed the hand-rolled dict + `clean_monitor` alias.
- **`config.py`**: `normalize_monitor()` replaces the manual backfill loop; `clean_monitor` and the duplicated `OPTIONAL_LIST_FIELDS` are deleted.

## Behavior preservation (verified end-to-end, not just unit tests)
- minimal create → identical 8-key tidy shape
- filters + `min_upvotes` round-trip; `min_upvotes: null` still stripped
- update merges known fields, re-validates, keeps `id`
- legacy monitors get backfilled **and bot-only fields survive**
- the bot still builds a `RedditMonitor` from a stored monitor

The only on-disk change is benign tidying of already-empty optional fields.

## Deferred
Fully modeling thread-monitor fields (`monitor_type` et al.) as typed model fields — they currently pass through untyped via `extra='allow'`. That's a phase-3 nicety, not needed for correctness.

## Testing
112 tests pass (incl. new model/normalization tests); `ruff` + `tsc` clean; generated types regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)